### PR TITLE
Make dlt optional

### DIFF
--- a/ivi-layermanagement-examples/simple-weston-client/CMakeLists.txt
+++ b/ivi-layermanagement-examples/simple-weston-client/CMakeLists.txt
@@ -26,7 +26,7 @@ pkg_check_modules(LIBWESTON_PROTOCOLS libweston-6-protocols QUIET)
 
 if(${LIBWESTON_PROTOCOLS_FOUND})
     #check for DLT
-    pkg_check_modules(DLT automotive-dlt REQUIRED)
+    pkg_check_modules(DLT automotive-dlt QUIET)
 
     #import the pkgdatadir from libweston-protocols pkgconfig file
     execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE} --variable=pkgdatadir libweston-6-protocols
@@ -118,8 +118,13 @@ add_dependencies(${PROJECT_NAME} ${LIBS})
 
 add_definitions(${DLT_CFLAGS})
 
+if(${DLT_FOUND})
+    add_definitions(-DDLT)
+endif(${DLT_FOUND})
+
 if(${LIBWESTON_PROTOCOLS_FOUND})
     add_definitions(-DLIBWESTON_DEBUG_PROTOCOL)
+    target_link_libraries(${PROJECT_NAME} pthread)
 endif(${LIBWESTON_PROTOCOLS_FOUND})
 
 target_link_libraries(${PROJECT_NAME} ${LIBS})

--- a/ivi-layermanagement-examples/simple-weston-client/src/simple-weston-client.c
+++ b/ivi-layermanagement-examples/simple-weston-client/src/simple-weston-client.c
@@ -810,7 +810,6 @@ int main (int argc, const char * argv[])
     BkGndSettingsStruct* bkgnd_settings;
 
     struct sigaction sigint;
-    int offset = 0;
     int ret = 0;
 
     sigint.sa_handler = signal_int;

--- a/ivi-layermanagement-examples/simple-weston-client/src/simple-weston-client.c
+++ b/ivi-layermanagement-examples/simple-weston-client/src/simple-weston-client.c
@@ -41,8 +41,7 @@
 #endif
 
 #ifdef DLT
-#include "dlt_common.h"
-#include "dlt_user.h"
+#include "dlt.h"
 
 #define WESTON_DLT_APP_DESC "messages from weston debug protocol"
 #define WESTON_DLT_CONTEXT_DESC "weston debug context"


### PR DESCRIPTION
dlt should be optional in the simple-weston-client and a few other adaptations 