### PR TITLE
Add support to build wayland-ivi-extension tests independently

### DIFF
--- a/ivi-layermanagement-api/test/CMakeLists.txt
+++ b/ivi-layermanagement-api/test/CMakeLists.txt
@@ -19,22 +19,36 @@
 
 CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
 
-FIND_PACKAGE(gtest)
-
-IF(NOT gtest_FOUND)
-    MESSAGE(STATUS "gtest not found, disabling unit tests (BUILD_ILM_API_TESTS=OFF)")
-    SET(BUILD_ILM_API_TESTS FALSE CACHE BOOL "Build unit tests for IVI LayerManagement API" FORCE)
-ENDIF()
+PROJECT(ivi-layermanagement-api-test)
 
 IF(BUILD_ILM_API_TESTS)
 
-    PROJECT(ivi-layermanagement-api-test)
+    SET(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/modules)
+    FIND_PACKAGE(gtest)
+
+IF(NOT gtest_FOUND)
+	MESSAGE(STATUS "gtest not found. Tests are not built, exiting.")
+ELSE()
+
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(WAYLAND_CLIENT REQUIRED wayland-client)
+
+    find_program(WAYLAND_SCANNER_EXECUTABLE NAMES wayland-scanner)
+
+    add_custom_command(
+        OUTPUT  ivi-application-client-protocol.h
+        COMMAND ${WAYLAND_SCANNER_EXECUTABLE} client-header
+                < ${CMAKE_CURRENT_SOURCE_DIR}/../../protocol/ivi-application.xml
+                > ${CMAKE_CURRENT_BINARY_DIR}/ivi-application-client-protocol.h
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../../protocol/ivi-application.xml
+    )
 
     INCLUDE_DIRECTORIES(
         ${CMAKE_CURRENT_SOURCE_DIR}/../ilmCommon/include
         ${CMAKE_CURRENT_SOURCE_DIR}/../ilmControl/include
         ${CMAKE_CURRENT_SOURCE_DIR}/../ilmInput/include
         ${CMAKE_CURRENT_BINARY_DIR}/../../protocol
+        ${CMAKE_CURRENT_BINARY_DIR}
         ${WAYLAND_CLIENT_INCLUDE_DIRS}
         ${gtest_INCLUDE_DIRS}
     )
@@ -58,6 +72,7 @@ IF(BUILD_ILM_API_TESTS)
         ilm_control_notification_test.cpp
         ilm_input_test.cpp
         ilm_input_null_pointer_test.cpp
+	ivi-application-client-protocol.h
     )
 
     SET(GCC_SANITIZER_COMPILE_FLAGS "-fsanitize=address -fsanitize=undefined -fno-sanitize-recover -fstack-protector-all")
@@ -78,4 +93,5 @@ IF(BUILD_ILM_API_TESTS)
     ADD_TEST(ilmControl ${PROJECT_NAME})
     ADD_TEST(ilmInput ${PROJECT_NAME})
 
+ENDIF()
 ENDIF() 


### PR DESCRIPTION
Currently to build wayland-ivi-extension test the whole component had to be built. Now added support to build tests independently.

Steps to build:
1. Pull the current codebase form the git repo
   E.g. git clone https://github.com/GENIVI/wayland-ivi-extension.git

2. Create a build directory in ivi-layermanagement-api/test 
   E.g mkdir build_ivi_extension

3. In **build-dir** Generate build system for your platform using CMake.
   E.g. cd **build-dir**
        cmake -DBUILD_ILM_API_TESTS=ON -DCMAKE_TOOLCHAIN_FILE=_your setting *.cmake_ ../

4. Start the build and install
   E.g. sudo make install

How to test:
1. After starting up Weston run the testsuite.
   Example: **your installation path**/bin/ivi-layermanagement-api-test

Signed-off-by: Girija B M <mohan.girija@in.bosch.com>