### PR TITLE
ivi-input-controller: Prevent use-after-free when tearing down seat

### DIFF
--- a/ivi-input-modules/ivi-input-controller/src/ivi-input-controller.c
+++ b/ivi-input-modules/ivi-input-controller/src/ivi-input-controller.c
@@ -917,18 +917,6 @@ destroy_seat(struct seat_ctx *ctx_seat)
 {
     struct ivisurface *surf;
     struct wl_resource *resource;
-    if (ctx_seat->keyboard_grab.keyboard) {
-    	keyboard_grab_cancel(&ctx_seat->keyboard_grab);
-        weston_keyboard_end_grab(ctx_seat->keyboard_grab.keyboard);
-    }
-    if (ctx_seat->pointer_grab.pointer) {
-    	pointer_grab_cancel(&ctx_seat->pointer_grab);
-        weston_pointer_end_grab(ctx_seat->pointer_grab.pointer);
-    }
-    if (ctx_seat->touch_grab.touch) {
-    	touch_grab_cancel(&ctx_seat->touch_grab);
-        weston_touch_end_grab(ctx_seat->touch_grab.touch);
-    }
 
     /* Remove seat acceptance from surfaces which have input acceptance from
      * this seat */


### PR DESCRIPTION
The seat destroy callback is triggered from weston_seat_release(),
that means the only way the code can enter destroy_seat() is with
all input devices associted with seat already released and all the
pointers already invalid. Avoid touching any of these input device
pointers in the destroy_seat() callback, otherwise this triggers
use-after-free condition.

ASan detects the use-after-free condition as follows:
```
==89420==ERROR: AddressSanitizer: heap-use-after-free on address 0x61100028e6a0 at pc 0x7f50deacb6fd bp 0x7ffed8504fe0 sp 0x7ffed8504fd8
WRITE of size 8 at 0x61100028e6a0 thread T0
  #0 0x7f50deacb6fc in weston_keyboard_end_grab ../libweston/input.c:1604
  #1 0x7f50bc6aac97 in destroy_seat (/tmp/wt/lib/x86_64-linux-gnu/weston/ivi-input-controller.so+0x7c97)
  #2 0x7f50bc6ab02f in handle_seat_destroy (/tmp/wt/lib/x86_64-linux-gnu/weston/ivi-input-controller.so+0x802f)
  #3 0x7f50deac477d in wl_signal_emit /usr/include/wayland-server-core.h:478
  #4 0x7f50dead5a93 in weston_seat_release ../libweston/input.c:3490
  #5 0x7f50bc6973d0 in ss_seat_destroy ../compositor/screen-share.c:395
  #6 0x7f50bc69922c in registry_handle_global_remove ../compositor/screen-share.c:751
  #7 0x7f50de8b89d9  (/lib/x86_64-linux-gnu/libffi.so.8+0x79d9)
  #8 0x7f50de8b7b20  (/lib/x86_64-linux-gnu/libffi.so.8+0x6b20)
  #9 0x7f50dea582d1  (/lib/x86_64-linux-gnu/libwayland-client.so.0+0x92d1)
  #10 0x7f50dea54979  (/lib/x86_64-linux-gnu/libwayland-client.so.0+0x5979)
  #11 0x7f50dea5603b in wl_display_dispatch_queue_pending (/lib/x86_64-linux-gnu/libwayland-client.so.0+0x703b)
  #12 0x7f50bc69931a in shared_output_handle_event ../compositor/screen-share.c:771
  #13 0x7f50dea434b1 in wl_event_loop_dispatch (/lib/x86_64-linux-gnu/libwayland-server.so.0+0xb4b1)
  #14 0x7f50dea41134 in wl_display_run (/lib/x86_64-linux-gnu/libwayland-server.so.0+0x9134)
  #15 0x7f50deed8489 in wet_main ../compositor/main.c:3564
  #16 0x55961496217d in main ../compositor/executable.c:33
  #17 0x7f50dece97ec in __libc_start_main ../csu/libc-start.c:332
  #18 0x559614962099 in _start (/tmp/wt/bin/weston+0x1099)
```