### PR TITLE
ivi-input-controller: Stop using frame_signal void *data parameter to get weston_output

### DIFF
--- a/weston-ivi-shell/src/ivi-controller.c
+++ b/weston-ivi-shell/src/ivi-controller.c
@@ -86,6 +86,7 @@ struct screenshot_frame_listener {
     struct wl_listener frame_listener;
     struct wl_listener output_destroyed;
     struct wl_resource *screenshot;
+    struct weston_output *output;
 };
 
 struct screen_id_info {
@@ -1206,7 +1207,7 @@ controller_screenshot_notify(struct wl_listener *listener, void *data)
     struct screenshot_frame_listener *l =
         wl_container_of(listener, l, frame_listener);
 
-    struct weston_output *output = data;
+    struct weston_output *output = l->output;
     int32_t width = 0;
     int32_t height = 0;
     int32_t stride = 0;
@@ -1336,6 +1337,7 @@ controller_screen_screenshot(struct wl_client *client,
         return;
     }
 
+    l->output = iviscrn->output;
     wl_resource_set_implementation(l->screenshot, NULL, l,
                                    screenshot_frame_listener_destroy);
     l->output_destroyed.notify = screenshot_output_destroyed;


### PR DESCRIPTION
Instead of getting weston_output from the frame_signal argument 'void *data',
add weston_output in the private data struct of the users that are listening
to frame_signal. With this change we are able to pass previous_damage as the
data argument.

This is similar to weston commit:
dd0d0b0d ("screenshooter: stop using frame_signal void *data parameter to get weston_output")