### PR TITLE
simple-weston-client: Repair array out of bounds access

### DIFF
--- a/ivi-layermanagement-examples/EGLWLInputEventExample/src/WLContext.cpp
+++ b/ivi-layermanagement-examples/EGLWLInputEventExample/src/WLContext.cpp
@@ -64,6 +64,7 @@ WLContext::~WLContext()
  * The following correspondences between file names and cursors was copied
  * from: https://bugs.kde.org/attachment.cgi?id=67313
  */
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
 
 static const char *left_ptrs[] = {
 	"left_ptr",
@@ -86,12 +87,12 @@ create_cursors(WLContext* wlContext)
 	}
 	wlContext->SetWLCursor((wl_cursor*) malloc(sizeof(wl_cursor)));
 
-	for (j = 0; !cursor && j < 4; ++j)
+	for (j = 0; !cursor && j < ARRAY_SIZE(left_ptrs); ++j)
 		cursor = wl_cursor_theme_get_cursor(wlContext->GetWLCursorTheme(),
 				left_ptrs[j]);
 
 	if (!cursor)
-		fprintf(stderr, "could not load cursor '%s'\n", left_ptrs[j]);
+		fprintf(stderr, "could not load any cursor\n");
 
 	wlContext->SetWLCursor(cursor);
 }

--- a/ivi-layermanagement-examples/simple-weston-client/src/simple-weston-client.c
+++ b/ivi-layermanagement-examples/simple-weston-client/src/simple-weston-client.c
@@ -98,6 +98,8 @@ struct debug_stream {
     struct weston_debug_stream_v1 *obj;
 };
 
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
+
 static const char *left_ptrs[] = {
     "left_ptr",
     "default",
@@ -270,12 +272,12 @@ static int create_cursors(WaylandContextStruct* wlcontext) {
 
     wlcontext->cursor = NULL;
 
-    for (j = 0; !wlcontext->cursor && j < 4; ++j)
+    for (j = 0; !wlcontext->cursor && j < ARRAY_SIZE(left_ptrs); ++j)
         wlcontext->cursor = wl_cursor_theme_get_cursor(wlcontext->cursor_theme, left_ptrs[j]);
 
     if (!wlcontext->cursor)
     {
-        fprintf(stderr, "could not load cursor '%s'\n", left_ptrs[j]);
+        fprintf(stderr, "could not load any cursor\n");
         return -1;
     }
 


### PR DESCRIPTION
Fix array out of bounds access detected by gcc format fortification check:

```
In file included from /test/recipe-sysroot/usr/include/stdio.h:867,
                 from /test/git/ivi-layermanagement-examples/simple-weston-client/src/simple-weston-client.c:23:
In function 'fprintf',
    inlined from 'create_cursors' at /test/git/ivi-layermanagement-examples/simple-weston-client/src/simple-weston-client.c:120:9,
    inlined from 'seat_handle_capabilities' at /test/git/ivi-layermanagement-examples/simple-weston-client/src/simple-weston-client.c:247:9:
/test/recipe-sysroot/usr/include/bits/stdio2.h:100:10: error: '%s' directive argument is null [-Werror=format-overflow=]
  100 |   return __fprintf_chk (__stream, __USE_FORTIFY_LEVEL - 1, __fmt,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  101 |    __va_arg_pack ());
      |    ~~~~~~~~~~~~~~~~~
```

The problem is in the `fprintf(..., left_ptrs[j])`, where if this code is
ever triggered, the variable `j=4` always, while the `left_ptrs` array only
has four entries instead of five, so the code would access one entry past
the array. In case this code is triggered, it does cause segmentation fault.