### PR TITLE
ivi-input-controller: ivi-controller: Copy over weston internal functions

### DIFF
--- a/ivi-input-modules/ivi-input-controller/src/ivi-input-controller.c
+++ b/ivi-input-modules/ivi-input-controller/src/ivi-input-controller.c
@@ -758,12 +758,29 @@ input_ctrl_touch_set_west_focus(struct seat_ctx *ctx_seat,
     }
 }
 
+/** Check if the touch has focused resources.
+ *
+ * \param touch The touch to check for focused resources.
+ * \return Whether or not this touch has focused resources
+ */
+static bool
+ivi_weston_touch_has_focus_resource(struct weston_touch *touch)
+{
+	if (!touch->focus)
+		return false;
+
+	if (wl_list_empty(&touch->focus_resource_list))
+		return false;
+
+	return true;
+}
+
 static void
 input_ctrl_touch_west_send_cancel(struct weston_touch *touch)
 {
     struct wl_resource *resource;
 
-    if (!weston_touch_has_focus_resource(touch))
+    if (!ivi_weston_touch_has_focus_resource(touch))
         return;
 
     wl_resource_for_each(resource, &touch->focus_resource_list)

--- a/weston-ivi-shell/src/ivi-controller.c
+++ b/weston-ivi-shell/src/ivi-controller.c
@@ -28,6 +28,7 @@
 
 #include "config.h"
 
+#include <errno.h>
 #include <fcntl.h>
 #include <unistd.h>
 #include <stdlib.h>
@@ -435,6 +436,42 @@ create_screenshot_file(off_t size) {
     return fd;
 }
 
+/** Read the current time from the Presentation clock
+ *
+ * \param compositor
+ * \param[out] ts The current time.
+ *
+ * \note Reading the current time in user space is always imprecise to some
+ * degree.
+ *
+ * This function is never meant to fail. If reading the clock does fail,
+ * an error message is logged and a zero time is returned. Callers are not
+ * supposed to detect or react to failures.
+ *
+ * \ingroup compositor
+ */
+static void
+ivi_weston_compositor_read_presentation_clock(
+			const struct weston_compositor *compositor,
+			struct timespec *ts)
+{
+	static bool warned;
+	int ret;
+
+	ret = clock_gettime(compositor->presentation_clock, ts);
+	if (ret < 0) {
+		ts->tv_sec = 0;
+		ts->tv_nsec = 0;
+
+		if (!warned)
+			weston_log("Error: failure to read "
+				   "the presentation clock %#x: '%s' (%d)\n",
+				   compositor->presentation_clock,
+				   strerror(errno), errno);
+		warned = true;
+	}
+}
+
 static void
 controller_surface_screenshot(struct wl_client *client,
                               struct wl_resource *resource,
@@ -518,7 +555,7 @@ controller_surface_screenshot(struct wl_client *client,
     }
 
     // get current timestamp
-    weston_compositor_read_presentation_clock(compositor, &stamp);
+    ivi_weston_compositor_read_presentation_clock(compositor, &stamp);
     stamp_ms = stamp.tv_sec * 1000 + stamp.tv_nsec / 1000000;
 
     ivi_screenshot_send_done(screenshot, fd, width, height, stride, format,
@@ -852,6 +889,23 @@ calc_trans_matrix(struct weston_geometry *source_rect,
     weston_matrix_translate(m, translate_x, translate_y, 0.0f);
 }
 
+/**
+ * \param surface  The surface to be repainted
+ *
+ * Marks the output(s) that the surface is shown on as needing to be
+ * repainted.  See weston_output_schedule_repaint().
+ */
+
+static void
+ivi_weston_surface_schedule_repaint(struct weston_surface *surface)
+{
+	struct weston_output *output;
+
+	wl_list_for_each(output, &surface->compositor->output_list, link)
+		if (surface->output_mask & (1u << output->id))
+			weston_output_schedule_repaint(output);
+}
+
 void
 set_bkgnd_surface_prop(struct ivishell *shell)
 {
@@ -909,7 +963,7 @@ set_bkgnd_surface_prop(struct ivishell *shell)
     wl_list_insert(&view->geometry.transformation_list,
                    &shell->bkgnd_transform.link);
     weston_view_update_transform(view);
-    weston_surface_schedule_repaint(w_surface);
+    ivi_weston_surface_schedule_repaint(w_surface);
 }
 
 static void
@@ -1304,6 +1358,20 @@ screenshot_frame_listener_destroy(struct wl_resource *resource)
     free(l);
 }
 
+/**
+ * \ingroup output
+ */
+static void
+ivi_weston_output_damage(struct weston_output *output)
+{
+	struct weston_compositor *compositor = output->compositor;
+
+	pixman_region32_union(&compositor->primary_plane.damage,
+			      &compositor->primary_plane.damage,
+			      &output->region);
+	weston_output_schedule_repaint(output);
+}
+
 static void
 controller_screen_screenshot(struct wl_client *client,
                              struct wl_resource *resource,
@@ -1343,7 +1411,7 @@ controller_screen_screenshot(struct wl_client *client,
     l->frame_listener.notify = controller_screenshot_notify;
     wl_signal_add(&iviscrn->output->frame_signal, &l->frame_listener);
     iviscrn->output->disable_planes++;
-    weston_output_damage(iviscrn->output);
+    ivi_weston_output_damage(iviscrn->output);
 }
 
 static void


### PR DESCRIPTION
Both ivi-controller and ivi-input-controller access functions which are
internal to weston, which means the ABI of these functions may change or
they may even be completely removed. So far, this wayland-ivi-extension
was able to link against libweston and use those functions by sheer luck,
but that may eventually run out. Copy over the internal functions as of
weston commit 2c1ed289 ("build: bump to version 9.0.92 for the beta release")