### PR TITLE
remove declaration of a global variable in a header file

### DIFF
--- a/ivi-layermanagement-api/ilmClient/include/ilm_client_platform.h
+++ b/ivi-layermanagement-api/ilmClient/include/ilm_client_platform.h
@@ -35,7 +35,7 @@ typedef struct _ILM_CLIENT_PLATFORM_FUNC
     ilmErrorTypes (*destroy)();
 } ILM_CLIENT_PLATFORM_FUNC;
 
-ILM_CLIENT_PLATFORM_FUNC gIlmClientPlatformFunc;
+extern ILM_CLIENT_PLATFORM_FUNC gIlmClientPlatformFunc;
 
 void init_ilmClientPlatformTable();
 

--- a/ivi-layermanagement-api/ilmClient/src/ilm_client_wayland_platform.c
+++ b/ivi-layermanagement-api/ilmClient/src/ilm_client_wayland_platform.c
@@ -27,6 +27,8 @@
 #include "wayland-util.h"
 #include "ivi-application-client-protocol.h"
 
+ILM_CLIENT_PLATFORM_FUNC gIlmClientPlatformFunc;
+
 static ilmErrorTypes wayland_surfaceCreate(t_ilm_nativehandle nativehandle,
                          t_ilm_int width, t_ilm_int height,
                          ilmPixelFormat pixelFormat,

--- a/ivi-layermanagement-api/ilmCommon/include/ilm_common_platform.h
+++ b/ivi-layermanagement-api/ilmCommon/include/ilm_common_platform.h
@@ -32,7 +32,7 @@ typedef struct _ILM_COMMON_PLATFORM_FUNC
     ilmErrorTypes (*destroy)();
 } ILM_COMMON_PLATFORM_FUNC;
 
-ILM_COMMON_PLATFORM_FUNC gIlmCommonPlatformFunc;
+extern ILM_COMMON_PLATFORM_FUNC gIlmCommonPlatformFunc;
 
 void init_ilmCommonPlatformTable();
 

--- a/ivi-layermanagement-api/ilmCommon/src/ilm_common_wayland_platform.c
+++ b/ivi-layermanagement-api/ilmCommon/src/ilm_common_wayland_platform.c
@@ -32,6 +32,8 @@ static t_ilm_nativedisplay wayland_getNativedisplay(void);
 static t_ilm_bool wayland_isInitialized(void);
 static ilmErrorTypes wayland_destroy(void);
 
+ILM_COMMON_PLATFORM_FUNC gIlmCommonPlatformFunc;
+
 void init_ilmCommonPlatformTable(void)
 {
     gIlmCommonPlatformFunc.init = wayland_init;


### PR DESCRIPTION
fixes following error with the gcc 11.2.0:

usr/bin/ld: CMakeFiles/ilmCommon.dir/src/ilm_common_wayland_platform.c.o:(.bss+0x0): multiple definition of `gIlmCommonPlatformFunc'; CMakeFiles/ilmCommon.dir/src/ilm_common.c.o:(.bss+0x0): first defined here
collect2: error: ld returned 1 exit status
make[2]: *** [ivi-layermanagement-api/ilmCommon/CMakeFiles/ilmCommon.dir/build.make:119: ivi-layermanagement-api/ilmCommon/libilmCommon.so.2.2.0] Error 1
make[1]: *** [CMakeFiles/Makefile2:511: ivi-layermanagement-api/ilmCommon/CMakeFiles/ilmCommon.dir/all] Error 2

ilm_client and ilm_common both has the same issue.
fix: move the declaration to the c file and define the variable as "external"
in the header file

Signed-off-by: Jeka Friedrich <friedrix@gmail.com>