### PR TITLE
protocol: Link ivi-application library with wayland-client library

### DIFF
--- a/protocol/CMakeLists.txt
+++ b/protocol/CMakeLists.txt
@@ -60,6 +60,11 @@ add_library(${PROJECT_NAME} SHARED
     ${CMAKE_CURRENT_BINARY_DIR}/ivi-application-protocol.c
 )
 
+target_link_libraries (
+  ${PROJECT_NAME}
+  ${WAYLAND_CLIENT_LIBRARIES}
+)
+
 set_target_properties(${PROJECT_NAME} PROPERTIES
                       COMPILE_FLAGS "-fPIC")
 


### PR DESCRIPTION
ivi-application library uses wayland-client library symbol:

```
aarch64-linux-gnu-objdump -TC libivi-application.so | grep wl_
0000000000000000      D  *UND*	0000000000000000              wl_surface_interface
```

but couldn't observe it in the library's 'Dynamic Section':

```
aarch64-linux-gnu-objdump -p libivi-application.so | grep NEEDED
  NEEDED               libc.so.6
```
Link libivi-application.so with libwayland-client.so to prevent undefined symbol errors.