### PR TITLE
EGLWLInputEventExample: fix crash when exit

### DIFF
--- a/ivi-layermanagement-examples/EGLWLInputEventExample/src/WLContext.cpp
+++ b/ivi-layermanagement-examples/EGLWLInputEventExample/src/WLContext.cpp
@@ -85,7 +85,6 @@ create_cursors(WLContext* wlContext)
 		fprintf(stderr, "could not load default theme\n");
 		return;
 	}
-	wlContext->SetWLCursor((wl_cursor*) malloc(sizeof(wl_cursor)));
 
 	for (j = 0; !cursor && j < ARRAY_SIZE(left_ptrs); ++j)
 		cursor = wl_cursor_theme_get_cursor(wlContext->GetWLCursorTheme(),
@@ -171,11 +170,10 @@ WLContext::SeatHandleCapabilities(void* data, struct wl_seat* seat, uint32_t cap
             context->ctx->SetPointerSurface(NULL);
         }
 
-        if (context->ctx->GetWLCursorTheme())
+        if (context->ctx->GetWLCursorTheme()){
             wl_cursor_theme_destroy(context->ctx->GetWLCursorTheme());
-
-        if (context->ctx->GetWLCursor())
-            free(context->ctx->GetWLCursor());
+            context->ctx->SetWLCursor(NULL);
+        }
     }
 
     if ((caps & WL_SEAT_CAPABILITY_KEYBOARD) && !context->wlKeyboard){
@@ -236,11 +234,11 @@ WLContext::DestroyWLContext()
         m_pointerSurface = NULL;
     }
 
-    if (m_wlCursorTheme)
+    if (m_wlCursorTheme){
         wl_cursor_theme_destroy(m_wlCursorTheme);
-
-    if (m_wlCursor)
-        free(m_wlCursor);
+        m_wlCursorTheme = NULL;
+        m_wlCursor = NULL;
+    }
 
     wl_registry_destroy(m_wlRegistry);
     wl_display_flush(m_wlDisplay);


### PR DESCRIPTION
We allocate the wl_cursor in the first step create_cursor, then tried to get the cursor object from wayland and override it. If wayland return a valid cursor, then when app exit, app and wayland tried to free it and we get the double free here.

Remove the allocation and free on the example to avoid double free.
![wlegl_input_core_dump](https://user-images.githubusercontent.com/113493212/203733757-03604541-b545-454b-a9ca-55ee56b86749.PNG)
