### PR TITLE
simple-weston-client: fix crash and hang when exiting

### DIFF
--- a/ivi-layermanagement-examples/simple-weston-client/src/simple-weston-client.c
+++ b/ivi-layermanagement-examples/simple-weston-client/src/simple-weston-client.c
@@ -887,24 +887,8 @@ int main (int argc, const char * argv[])
 
 Error:
 #ifdef LIBWESTON_DEBUG_PROTOCOL
-    weston_debug_v1_destroy(wlcontext->debug_iface);
-
-    while (1) {
-        struct debug_stream *stream;
-        int empty = 1;
-
-        wl_list_for_each(stream, &wlcontext->stream_list, link)
-            if (stream->obj) {
-                empty = 0;
-                break;
-            }
-
-        if (empty)
-            break;
-
-        if (wl_display_dispatch(wlcontext->wl_display) < 0)
-            break;
-    }
+    if(wlcontext->debug_iface)
+        weston_debug_v1_destroy(wlcontext->debug_iface);
 
     destroy_streams(wlcontext);
     wl_display_roundtrip(wlcontext->wl_display);


### PR DESCRIPTION
wlcontext->debug_iface didn't bind when weston has been running with non debug option. So, we need to check it before call weston_debug_v1_destroy.

Need to remove the while loop after send SIGINT, the stream->ojb always availbe in this case, then it makes a hang here.

![simple-weston-client](https://user-images.githubusercontent.com/113493212/204758734-c206f942-6c36-403f-8fc4-fac4153bda85.PNG)
