### PR TITLE
ivi-id-agent: Fix invalid read reported by valgrind while stopping We…

### DIFF
--- a/ivi-id-agent-modules/ivi-id-agent/src/ivi-id-agent.c
+++ b/ivi-id-agent-modules/ivi-id-agent/src/ivi-id-agent.c
@@ -365,8 +365,10 @@ ivi_failed:
 static int32_t
 deinit(struct ivi_id_agent *ida)
 {
-    struct db_elem *db_elem;
-    wl_list_for_each(db_elem, &ida->app_list, link) {
+    struct db_elem *db_elem, *dl_elem_next;
+    wl_list_for_each_safe(db_elem, dl_elem_next, &ida->app_list, link) {
+        wl_list_remove(&db_elem->link);
+
         free(db_elem->cfg_app_id);
         free(db_elem->cfg_title);
         free(db_elem);


### PR DESCRIPTION
…ston

Valgrind reports the following issue while stopping Weston.

```
==2459== Invalid read of size 8
==2459==    at 0x7169040: deinit (ivi-id-agent.c:369)
==2459==    by 0x488E98F: wl_signal_emit (wayland-server-core.h:394)
==2459==    by 0x488E98F: weston_compositor_tear_down (compositor.c:7686)
==2459==    by 0x40681F: main (main.c:3397)
```

The elements of application list are not properly destroyed as it's link to the list exists even after deletion.
Remove the element link using wl_list_remove() and use wl_list_for_each_safe() to safely iterate through the list.