### PR TITLE
multi-touch-viewer: add the surface selection optional

### DIFF
--- a/ivi-layermanagement-examples/multi-touch-viewer/include/window.h
+++ b/ivi-layermanagement-examples/multi-touch-viewer/include/window.h
@@ -46,6 +46,12 @@ struct Task
     struct wl_list link;
 };
 
+enum TypeOfShell
+{
+    WL_SHELL  = 1,
+    IVI_SHELL = 2
+};
+
 struct WaylandDisplay
 {
     struct Task           display_task;
@@ -57,6 +63,7 @@ struct WaylandDisplay
     EGLDisplay            egldisplay;
     EGLConfig             eglconfig;
     EGLContext            eglcontext;
+    enum TypeOfShell      shell_type;
 
     int                   running;
     int                   epoll_fd;
@@ -102,7 +109,7 @@ struct WaylandEglWindow
 };
 
 struct WaylandDisplay*
-CreateDisplay(int argc, char **argv);
+CreateDisplay(int argc, char **argv, enum TypeOfShell shell_type);
 
 void
 DestroyDisplay(struct WaylandDisplay *p_display);

--- a/ivi-layermanagement-examples/multi-touch-viewer/src/window.c
+++ b/ivi-layermanagement-examples/multi-touch-viewer/src/window.c
@@ -79,12 +79,14 @@ registry_handle_global(void *p_data, struct wl_registry *p_registry,
         p_display->p_compositor = wl_registry_bind(p_registry, id,
             &wl_compositor_interface, 1);
     }
-    else if (0 == strcmp(p_interface, "wl_shell"))
+    else if ((0 == strcmp(p_interface, "wl_shell")) &&
+            (p_display->shell_type == WL_SHELL))
     {
         p_display->p_shell = wl_registry_bind(p_registry, id,
             &wl_shell_interface, 1);
     }
-    else if (0 == strcmp(p_interface, "ivi_application"))
+    else if ((0 == strcmp(p_interface, "ivi_application")) &&
+            (p_display->shell_type == IVI_SHELL))
     {
         p_display->p_ivi_application = wl_registry_bind(p_registry, id,
             &ivi_application_interface, 1);
@@ -500,7 +502,7 @@ DisplayAcquireWindowSurface(struct WaylandDisplay *p_display,
 }
 
 struct WaylandDisplay *
-CreateDisplay(int argc, char **argv)
+CreateDisplay(int argc, char **argv, enum TypeOfShell shell_type)
 {
     struct WaylandDisplay *p_display;
 
@@ -521,6 +523,7 @@ CreateDisplay(int argc, char **argv)
         return NULL;
     }
 
+    p_display->shell_type = shell_type;
     p_display->epoll_fd = os_epoll_create_cloexec();
     p_display->display_fd = wl_display_get_fd(p_display->p_display);
     p_display->display_task.run = handle_display_data;


### PR DESCRIPTION
only a wl_shell or ivi surface is created base on wl_surface. we should select of the type of surface via input argument.
-s optional is added to example, if the input is 1, client will run with wl_shell. if option don't set or other value, the ivi surface is set.