### PR TITLE
Weston 11 compatible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,8 @@ include(GNUInstallDirs)
 SET(IVI_EXTENSION_VERSION 2.3.0)
 SET(ILM_API_VERSION 2.3.0)
 
+SET(LIBWESTON_VER 11)
+
 SET( CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -Wall -Wextra -Wno-unused-parameter" )
 SET( CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-unused-parameter" )
 

--- a/ivi-id-agent-modules/ivi-id-agent/CMakeLists.txt
+++ b/ivi-id-agent-modules/ivi-id-agent/CMakeLists.txt
@@ -25,8 +25,8 @@ find_package(PkgConfig REQUIRED)
 pkg_check_modules(WAYLAND_SERVER wayland-server REQUIRED)
 pkg_check_modules(WESTON weston>=6.0.0 REQUIRED)
 pkg_check_modules(PIXMAN pixman-1 REQUIRED)
-pkg_check_modules(LIBWESTON_DESKTOP libweston-desktop-10 REQUIRED)
-pkg_check_modules(LIBWESTON libweston-10 REQUIRED)
+pkg_check_modules(LIBWESTON libweston-${LIBWESTON_VER} REQUIRED)
+pkg_check_modules(LIBWESTON_DESKTOP libweston-desktop-${LIBWESTON_VER} REQUIRED)
 
 find_package(Threads REQUIRED)
 

--- a/ivi-input-modules/ivi-input-controller/CMakeLists.txt
+++ b/ivi-input-modules/ivi-input-controller/CMakeLists.txt
@@ -25,7 +25,7 @@ find_package(PkgConfig REQUIRED)
 pkg_check_modules(WAYLAND_SERVER wayland-server REQUIRED)
 pkg_check_modules(WESTON weston>=5.0.0 REQUIRED)
 pkg_check_modules(PIXMAN pixman-1 REQUIRED)
-pkg_check_modules(LIBWESTON libweston-10 REQUIRED)
+pkg_check_modules(LIBWESTON libweston-${LIBWESTON_VER} REQUIRED)
 
 GET_TARGET_PROPERTY(ILM_COMMON_INCLUDE_DIRS ilmCommon INCLUDE_DIRECTORIES)
 GET_TARGET_PROPERTY(IVI_CONTROLLER_INCLUDE_DIRS ivi-controller INCLUDE_DIRECTORIES)

--- a/ivi-layermanagement-examples/simple-weston-client/CMakeLists.txt
+++ b/ivi-layermanagement-examples/simple-weston-client/CMakeLists.txt
@@ -22,14 +22,14 @@ project (simple-weston-client)
 find_package(PkgConfig)
 pkg_check_modules(WAYLAND_CLIENT wayland-client REQUIRED)
 pkg_check_modules(WAYLAND_CURSOR wayland-cursor REQUIRED)
-pkg_check_modules(LIBWESTON_PROTOCOLS libweston-10-protocols QUIET)
+pkg_check_modules(LIBWESTON_PROTOCOLS libweston-${LIBWESTON_VER}-protocols QUIET)
 
 if(${LIBWESTON_PROTOCOLS_FOUND})
     #check for DLT
     pkg_check_modules(DLT automotive-dlt QUIET)
 
     #import the pkgdatadir from libweston-protocols pkgconfig file
-    execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE} --variable=pkgdatadir libweston-10-protocols
+    execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE} --variable=pkgdatadir libweston-${LIBWESTON_VER}-protocols
                     OUTPUT_VARIABLE WestonProtocols_PKGDATADIR)
     string(REGEX REPLACE "[\r\n]" "" WestonProtocols_PKGDATADIR "${WestonProtocols_PKGDATADIR}")
     SET(LIBWESTON_PROTOCOLS_PKGDATADIR ${WestonProtocols_PKGDATADIR})

--- a/weston-ivi-shell/CMakeLists.txt
+++ b/weston-ivi-shell/CMakeLists.txt
@@ -26,7 +26,7 @@ find_package(PkgConfig REQUIRED)
 pkg_check_modules(WAYLAND_SERVER wayland-server>=1.13.0 REQUIRED)
 pkg_check_modules(WESTON weston>=5.0.0 REQUIRED)
 pkg_check_modules(PIXMAN pixman-1 REQUIRED)
-pkg_check_modules(LIBWESTON libweston-10 REQUIRED)
+pkg_check_modules(LIBWESTON libweston-${LIBWESTON_VER} REQUIRED)
 
 find_program(WAYLAND_SCANNER_EXECUTABLE NAMES wayland-scanner)
 


### PR DESCRIPTION
CMakeLists: update libweston to version 11
Update the libweston-11 on ivi-id-agent cmake file.
Update the libweston-11-protocols on simple-weston-client cmake file