### PR TITLE
IlmControl: Fix no warning when passing an invalid surface to function input_listener_input_acceptance

### DIFF
--- a/ivi-layermanagement-api/ilmControl/src/ilm_control_wayland_platform.c
+++ b/ivi-layermanagement-api/ilmControl/src/ilm_control_wayland_platform.c
@@ -833,7 +833,7 @@ input_listener_input_acceptance(void *data,
     struct accepted_seat *accepted_seat, *next;
     struct wayland_context *ctx = data;
     struct surface_context *surface_ctx = NULL;
-    int surface_found = 1;
+    int surface_found = 0;
     int accepted_seat_found = 0;
 
     wl_list_for_each(surface_ctx, &ctx->list_surface, link) {


### PR DESCRIPTION
In function input_listener_input_acceptance, variable "surface_found" should be initialized to 0.
Only then "if(!surface_found)" will take effect.

Signed-off-by: Au Doan Ngoc <au.doanngoc@vn.bosch.com>