### PR TITLE
tests: add the ilm env checking test

### DIFF
--- a/ivi-layermanagement-api/test/CMakeLists.txt
+++ b/ivi-layermanagement-api/test/CMakeLists.txt
@@ -30,20 +30,53 @@ IF(BUILD_ILM_API_TESTS)
 
     PROJECT(ivi-layermanagement-api-test)
 
-    INCLUDE_DIRECTORIES(
-        ${CMAKE_CURRENT_SOURCE_DIR}/../ilmCommon/include
-        ${CMAKE_CURRENT_SOURCE_DIR}/../ilmControl/include
-        ${CMAKE_CURRENT_SOURCE_DIR}/../ilmInput/include
-        ${CMAKE_CURRENT_BINARY_DIR}/../../protocol
-        ${WAYLAND_CLIENT_INCLUDE_DIRS}
-        ${gtest_INCLUDE_DIRS}
+    SET(TARGET_API ivi-layermanagement-api-test)
+    SET(TARGET_ENV_CHECKING ivi-layermanagement-env-checking-test)
+
+    find_program(WAYLAND_SCANNER_EXECUTABLE NAMES wayland-scanner)
+
+    add_custom_command(
+        OUTPUT  ivi-wm-client-protocol.h
+        COMMAND ${WAYLAND_SCANNER_EXECUTABLE} client-header
+                < ${CMAKE_SOURCE_DIR}/protocol/ivi-wm.xml
+                > ${CMAKE_CURRENT_BINARY_DIR}/ivi-wm-client-protocol.h
+        DEPENDS ${CMAKE_SOURCE_DIR}/protocol/ivi-wm.xml
+    )
+
+    add_custom_command(
+        OUTPUT  ivi-wm-protocol.c
+        COMMAND ${WAYLAND_SCANNER_EXECUTABLE} code
+                < ${CMAKE_SOURCE_DIR}/protocol/ivi-wm.xml
+                > ${CMAKE_CURRENT_BINARY_DIR}/ivi-wm-protocol.c
+        DEPENDS ${CMAKE_SOURCE_DIR}/protocol/ivi-wm.xml
+    )
+
+    add_custom_command(
+        OUTPUT  ivi-input-client-protocol.h
+        COMMAND ${WAYLAND_SCANNER_EXECUTABLE} client-header
+                < ${CMAKE_SOURCE_DIR}/protocol/ivi-input.xml
+                > ${CMAKE_CURRENT_BINARY_DIR}/ivi-input-client-protocol.h
+        DEPENDS ${CMAKE_SOURCE_DIR}/protocol/ivi-input.xml
+    )
+
+    add_custom_command(
+        OUTPUT  ivi-input-protocol.c
+        COMMAND ${WAYLAND_SCANNER_EXECUTABLE} code
+                < ${CMAKE_SOURCE_DIR}/protocol/ivi-input.xml
+                > ${CMAKE_CURRENT_BINARY_DIR}/ivi-input-protocol.c
+        DEPENDS ${CMAKE_SOURCE_DIR}/protocol/ivi-input.xml
     )
 
     LINK_DIRECTORIES(
         ${WAYLAND_CLIENT_LIBRARY_DIRS}
     )
 
-    SET(LIBS
+    SET(GCC_SANITIZER_COMPILE_FLAGS "-fsanitize=address -fsanitize=undefined -fno-sanitize-recover -fstack-protector-all")
+    SET( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GCC_SANITIZER_COMPILE_FLAGS}" )
+    SET( CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} -static-libasan -static-libubsan" )
+
+    #api tests
+    SET(TARGET_API_LIBS
         ilmCommon
         ilmControl
         ilmInput
@@ -51,31 +84,53 @@ IF(BUILD_ILM_API_TESTS)
         ${gtest_LIBRARIES}
         ${WAYLAND_CLIENT_LIBRARIES}
     )
-
-    SET(SRC_FILES
+    SET(TARGET_API_SRC_FILES
         TestBase.cpp
         ilm_control_test.cpp
         ilm_control_notification_test.cpp
         ilm_input_test.cpp
         ilm_input_null_pointer_test.cpp
     )
+    ADD_EXECUTABLE(${TARGET_API} ${TARGET_API_SRC_FILES})
+    TARGET_INCLUDE_DIRECTORIES(${TARGET_API}
+        PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/../ilmCommon/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/../ilmControl/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/../ilmInput/include
+        ${CMAKE_CURRENT_BINARY_DIR}/../../protocol
+        ${WAYLAND_CLIENT_INCLUDE_DIRS}
+        ${gtest_INCLUDE_DIRS}
+    )
+    TARGET_LINK_LIBRARIES(${TARGET_API} ${TARGET_API_LIBS})
+    ADD_DEPENDENCIES(${TARGET_API} ${TARGET_API_LIBS})
+    INSTALL(TARGETS ${TARGET_API} DESTINATION bin)
 
-    SET(GCC_SANITIZER_COMPILE_FLAGS "-fsanitize=address -fsanitize=undefined -fno-sanitize-recover -fstack-protector-all")
-    SET( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GCC_SANITIZER_COMPILE_FLAGS}" )
-    SET( CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} -static-libasan -static-libubsan" )
-
-    ADD_EXECUTABLE(${PROJECT_NAME} ${SRC_FILES})
-
-    TARGET_LINK_LIBRARIES(${PROJECT_NAME} ${LIBS})
-
-    ADD_DEPENDENCIES(${PROJECT_NAME} ${LIBS})
-
-    INSTALL(TARGETS ${PROJECT_NAME} DESTINATION bin)
+    # check env test
+    SET(TARGET_ENV_CHECKING_LIBS
+        ${gtest_LIBRARIES}
+        ${WAYLAND_CLIENT_LIBRARIES}
+    )
+    SET(TARGET_ENV_CHECKING_SRC_FILES
+        ivi-wm-client-protocol.h
+        ivi-wm-protocol.c
+        ivi-input-client-protocol.h
+        ivi-input-protocol.c
+        ilm_check_env.cpp
+    )
+    ADD_EXECUTABLE(${TARGET_ENV_CHECKING} ${TARGET_ENV_CHECKING_SRC_FILES})
+    TARGET_INCLUDE_DIRECTORIES(${TARGET_ENV_CHECKING}
+        PUBLIC
+        ${WAYLAND_CLIENT_INCLUDE_DIRS}
+        ${gtest_INCLUDE_DIRS}
+        ${CMAKE_CURRENT_BINARY_DIR}
+    )
+    TARGET_LINK_LIBRARIES(${TARGET_ENV_CHECKING} ${TARGET_ENV_CHECKING_LIBS})
+    ADD_DEPENDENCIES(${TARGET_ENV_CHECKING} ${TARGET_ENV_CHECKING_LIBS})
+    INSTALL(TARGETS ${TARGET_ENV_CHECKING} DESTINATION bin)
 
     # use CTest
     ENABLE_TESTING()
-    ADD_TEST(ilmCommon  ${PROJECT_NAME})
-    ADD_TEST(ilmControl ${PROJECT_NAME})
-    ADD_TEST(ilmInput ${PROJECT_NAME})
+    ADD_TEST(NAME ${TARGET_API} COMMAND ${TARGET_API})
+    ADD_TEST(NAME ${TARGET_ENV_CHECKING} COMMAND ${TARGET_ENV_CHECKING})
 
 ENDIF() 

--- a/ivi-layermanagement-api/test/ilm_check_env.cpp
+++ b/ivi-layermanagement-api/test/ilm_check_env.cpp
@@ -1,0 +1,176 @@
+/***************************************************************************
+ *
+ * Copyright (C) 2023 Advanced Driver Information Technology Joint Venture GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ****************************************************************************/
+
+#include <gtest/gtest.h>
+#include <wayland-client.h>
+#include "ivi-input-client-protocol.h"
+#include "ivi-wm-client-protocol.h"
+
+class TestEnvChecking
+{
+  public:
+    struct wl_display  *mpDisplay;
+    struct wl_registry *mpRegistry;
+
+    struct ivi_wm *mpController;
+    struct ivi_input *mpInputController;
+    bool mCheck;
+
+    static constexpr uint32_t IVI_CONTROLLER_VERSION{1U};
+    static constexpr uint32_t IVI_INPUT_VERSION{2U};
+
+    static TestEnvChecking *GetInstance();
+    ~TestEnvChecking();
+
+  private:
+    static void RegistryHandleGlobal(void *apData, struct wl_registry *apRegistry,
+        uint32_t aId,
+        const char *acpInterface,
+        uint32_t aVersion);
+
+    static constexpr struct wl_registry_listener mRegistryListener = {
+      RegistryHandleGlobal,
+      nullptr
+    };
+
+    static TestEnvChecking *mpInstance;
+    TestEnvChecking();
+};
+
+TestEnvChecking* TestEnvChecking::mpInstance{nullptr};
+
+TestEnvChecking::TestEnvChecking(): mpDisplay(nullptr), mpRegistry(nullptr),
+    mpController(nullptr),
+    mpInputController(nullptr),
+    mCheck(true)
+{
+  int ret;
+
+  mpDisplay = wl_display_connect(nullptr);
+  if (mpDisplay == nullptr) {
+    printf("ERROR: Failed to wl_display_connect()\n");
+    mCheck = false;
+    return;
+  }
+
+  mpRegistry = wl_display_get_registry(mpDisplay);
+  if (mpRegistry == nullptr) {
+    printf("ERROR: Failed to wl_display_get_registry()\n");
+    mCheck = false;
+    return;
+  }
+
+  ret = wl_registry_add_listener(mpRegistry, &mRegistryListener, this);
+  if (ret < 0) {
+    printf("ERROR: Failed to wl_registry_add_listener()\n");
+    mCheck = false;
+    return;
+  }
+
+  ret = wl_display_roundtrip(mpDisplay);
+  if (ret < 0) {
+    printf("ERROR: Failed to wl_display_roundtrip()\n");
+    mCheck = false;
+    return;
+  }
+
+  if ((mpController == nullptr) || (mpInputController == nullptr)) {
+    printf("ERROR: can't get the ivi_wm (%lX) or ivi_input (%lX) protocols from compositor.\n",
+        reinterpret_cast<uintptr_t>(mpController),
+        reinterpret_cast<uintptr_t>(mpInputController));
+    mCheck = false;
+    return;
+  }
+}
+
+TestEnvChecking::~TestEnvChecking()
+{
+  if (!mpInputController) {
+    ivi_input_destroy(mpInputController);
+  }
+
+  if (!mpController) {
+    ivi_wm_destroy(mpController);
+  }
+
+  if (!mpRegistry) {
+    wl_registry_destroy(mpRegistry);
+  }
+
+  if (!mpDisplay) {
+    wl_display_disconnect(mpDisplay);
+  }
+}
+
+void TestEnvChecking::RegistryHandleGlobal(void *apData, struct wl_registry *apRegistry,
+    uint32_t aId,
+    const char *acpInterface,
+    uint32_t aVersion)
+{
+  TestEnvChecking *lpTestEnvChecking = reinterpret_cast<TestEnvChecking*>(apData);
+
+  if (0 == strcmp(acpInterface, "ivi_wm")) {
+    if (IVI_CONTROLLER_VERSION != aVersion) {
+      printf("ERROR: unexpected ivi_wm version from server. Expected: %d, got: %d\n",
+          IVI_CONTROLLER_VERSION,
+          aVersion);
+      lpTestEnvChecking->mCheck = false;
+      return;
+    }
+
+    lpTestEnvChecking->mpController = reinterpret_cast<struct ivi_wm*>
+        (wl_registry_bind(apRegistry, aId, &ivi_wm_interface, IVI_CONTROLLER_VERSION));
+    if (lpTestEnvChecking->mpController == nullptr) {
+      printf("ERROR: Failed to wl_registry_bind ivi_wm\n");
+      lpTestEnvChecking->mCheck = false;
+      return;
+    }
+  }
+  else if (0 == strcmp(acpInterface, "ivi_input")) {
+    if (IVI_INPUT_VERSION != aVersion) {
+      printf("ERROR: unexpected ivi_input version from server. Expected: %d, got: %d\n",
+          IVI_INPUT_VERSION,
+          aVersion);
+      lpTestEnvChecking->mCheck = false;
+      return;
+    }
+
+    lpTestEnvChecking->mpInputController = reinterpret_cast<struct ivi_input*>
+        (wl_registry_bind(apRegistry, aId, &ivi_input_interface, IVI_INPUT_VERSION));
+    if (lpTestEnvChecking->mpInputController == nullptr) {
+      printf("ERROR: Failed to wl_registry_bind ivi_input\n");
+      lpTestEnvChecking->mCheck = false;
+      return;
+    }
+  }
+}
+
+TestEnvChecking *TestEnvChecking::GetInstance()
+{
+  if (mpInstance == nullptr) {
+    mpInstance = new TestEnvChecking();
+  }
+  return mpInstance;
+}
+
+TEST(ilm_test, env_checking)
+{
+  TestEnvChecking *lpTestEnvChecking = TestEnvChecking::GetInstance();
+  ASSERT_TRUE(lpTestEnvChecking->mCheck);
+}


### PR DESCRIPTION
The environment checking test verifies the versions of ivi_wm and ivi_input from compositor. It makes sure the server is providing the client's expectation versions.

It also tries to bind the protocols via registry.