### PR TITLE
ivi-controller: update data type of member in struct ivishell

### DIFF
--- a/weston-ivi-shell/src/ivi-controller.c
+++ b/weston-ivi-shell/src/ivi-controller.c
@@ -2063,7 +2063,7 @@ get_config(struct weston_compositor *compositor, struct ivishell *shell)
 
 	weston_config_section_get_bool(section,
 	                   "enable-cursor",
-	                   &shell->enable_cursor, 0);
+	                   &shell->enable_cursor, false);
 
 	wl_array_init(&shell->screen_ids);
 

--- a/weston-ivi-shell/src/ivi-controller.h
+++ b/weston-ivi-shell/src/ivi-controller.h
@@ -87,7 +87,7 @@ struct ivishell {
 
     int32_t bkgnd_surface_id;
     uint32_t bkgnd_color;
-    int enable_cursor;
+    bool enable_cursor;
     struct ivisurface *bkgnd_surface;
     struct weston_layer bkgnd_layer;
     struct weston_view  *bkgnd_view;


### PR DESCRIPTION
From weston version 8.0.0, data type of param in
weston_config_section_get_bool() changed from int to bool. So, we need to update in wayland-ivi-extension source.

(< version 8.0.0 )
![image](https://user-images.githubusercontent.com/110008473/230341796-a950cff1-1548-4973-9bbd-c1bfee93f98c.png)

(>= version 8.0.0)
![image](https://user-images.githubusercontent.com/110008473/230341876-1f4d668a-9968-4c49-a652-647aec61e2ba.png)
