### PR TITLE
bump 2.3.0 version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,8 +25,8 @@ project(wayland-ivi-extension)
 
 include(GNUInstallDirs)
 
-SET(IVI_EXTENSION_VERSION 2.2.0)
-SET(ILM_API_VERSION 2.2.0)
+SET(IVI_EXTENSION_VERSION 2.3.0)
+SET(ILM_API_VERSION 2.3.0)
 
 SET( CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -Wall -Wextra -Wno-unused-parameter" )
 SET( CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-unused-parameter" )


### PR DESCRIPTION
2.3.0 version
this commit will be the last compatible version with weston 9

new api's:
    ilm_getDefaultSeat
        get the name of default seat

    ilm_takeAsyncScreenshot
    ilm_takeAsyncSurfaceScreenshot
	both api's provides a way to get the screenshot of the screen or particular surface in asynchronous manner, user will be notified via callback

other updates:

Tran Ba Khang:
    simple-weston-client.c: avoid to use STDOUT_FILENO and STDIN_FILENO
    ivi-controller: set surface background color from client side
    ilm_input_test: update tests with default seat
    ilmInput: support ilm_getDefaultSeat api to return default seat name
    ivi-input-modules: read default seat name from weston.ini file
    tests: add the ilm env checking test
    CMakeLists: update libweston to version 9
    tests: create tests for new screenshot functions with callbacks

Au Doan Ngoc:
    ivi-controller: update data type of member in struct ivishell
    ivi-controller: Fix the problem of assigning an address to a pointer

Rajendraprasad K J:
    CMake: Specify generic library destination for installation
    simple-weston-client: Improve signal handling

Marek Vasut:
    ilmControl: Extend screenshot API with callback support


Signed-off-by: Eugen Friedrich <efriedrich@de.adit-jv.com>