### PR TITLE
ivi-controller: set surface background color from client side

### DIFF
--- a/ivi-layermanagement-examples/simple-weston-client/src/simple-weston-client.c
+++ b/ivi-layermanagement-examples/simple-weston-client/src/simple-weston-client.c
@@ -63,6 +63,7 @@ typedef struct _BkGndSettings
     uint32_t surface_width;
     uint32_t surface_height;
     uint32_t surface_stride;
+    uint32_t bkgnd_color;
 }BkGndSettingsStruct;
 
 typedef struct _WaylandContext {
@@ -131,6 +132,12 @@ get_bkgnd_settings_cursor_info(WaylandContextStruct* wlcontext)
         bkgnd_settings->surface_id = strtol(option, &end, 0);
     else
         bkgnd_settings->surface_id = 10;
+
+    option = getenv("IVI_CLIENT_BKGND_COLOR");
+    if(option)
+        bkgnd_settings->bkgnd_color = strtol(option, &end, 0);
+    else
+        bkgnd_settings->bkgnd_color = 0xFF000000;
 
     bkgnd_settings->surface_width = 1;
     bkgnd_settings->surface_height = 1;
@@ -655,10 +662,12 @@ create_shm_buffer(WaylandContextStruct* wlcontext)
 int draw_bkgnd_surface(WaylandContextStruct* wlcontext)
 {
     BkGndSettingsStruct *bkgnd_settings = wlcontext->bkgnd_settings;
-    uint32_t* pixels;
-
-    pixels = (uint32_t*)wlcontext->bkgnddata;
-    *pixels = 0x0;
+    /*The buffer size only 4 bytes.
+     * @todo may need to use the cairo lib to set color
+     * keep this simple for review solution.
+    */
+    uint32_t *pixels = (uint32_t*)wlcontext->bkgnddata;
+    *pixels = bkgnd_settings->bkgnd_color;
 
     wl_surface_attach(wlcontext->wlBkgndSurface, wlcontext->wlBkgndBuffer, 0, 0);
     wl_surface_damage(wlcontext->wlBkgndSurface, 0, 0,

--- a/weston-ivi-shell/src/ivi-controller.c
+++ b/weston-ivi-shell/src/ivi-controller.c
@@ -43,6 +43,7 @@
 #include "wayland-util.h"
 
 #define IVI_CLIENT_SURFACE_ID_ENV_NAME "IVI_CLIENT_SURFACE_ID"
+#define IVI_CLIENT_BKGND_COLOR_ENV_NAME "IVI_CLIENT_BKGND_COLOR"
 #define IVI_CLIENT_DEBUG_SCOPES_ENV_NAME "IVI_CLIENT_DEBUG_STREAM_NAMES"
 #define IVI_CLIENT_ENABLE_CURSOR_ENV_NAME "IVI_CLIENT_ENABLE_CURSOR"
 
@@ -1891,18 +1892,9 @@ surface_event_configure(struct wl_listener *listener, void *data)
 
     surface_id = lyt->get_id_of_surface(layout_surface);
     if (shell->bkgnd_surface_id == (int32_t)surface_id) {
-        float red, green, blue, alpha;
 
         if (!shell->bkgnd_view) {
             w_surface = lyt->surface_get_weston_surface(layout_surface);
-
-            alpha = ((shell->bkgnd_color >> 24) & 0xFF) / 255.0F;
-            red = ((shell->bkgnd_color >> 16) & 0xFF) / 255.0F;
-            green = ((shell->bkgnd_color >> 8) & 0xFF) / 255.0F;
-            blue = (shell->bkgnd_color & 0xFF) / 255.0F;
-
-            weston_surface_set_color(w_surface, red, green, blue, alpha);
-
             wl_list_init(&shell->bkgnd_transform.link);
             shell->bkgnd_view = weston_view_create(w_surface);
             weston_layer_entry_insert(&shell->bkgnd_layer.view_list,
@@ -2265,6 +2257,9 @@ launch_client_process(void *data)
 
     sprintf(option, "%d", shell->bkgnd_surface_id);
     setenv(IVI_CLIENT_SURFACE_ID_ENV_NAME, option, 0x1);
+    sprintf(option, "%d", shell->bkgnd_color);
+    setenv(IVI_CLIENT_BKGND_COLOR_ENV_NAME, option, 0x1);
+
     if (shell->debug_scopes) {
         setenv(IVI_CLIENT_DEBUG_SCOPES_ENV_NAME, shell->debug_scopes, 0x1);
         free(shell->debug_scopes);


### PR DESCRIPTION
The weston_surface_set_color should be only called to setup the color of a surface without a buffer attached (BUFFER_TYPE_SOLID). Currently, ivi-controller is used it to setting the color of a background surface with type of buffer is SHM.

On weston 10, with commit [1], it don't allow to re-draw a surface if getting an unexpected of shader properties, we will get an assertion.

On weston 11, with the commit [2], weston will remove the weston_surface_set_color api, we can't use it any more.

On hmi-controller and desktop-shell, filling the image or color of the backgound is done by client. Just follow this way in ivi-controller.

[1] https://gitlab.freedesktop.org/wayland/weston/-/commit/0f52da62
[2] https://gitlab.freedesktop.org/wayland/weston/-/commit/b5605ccd