### PR TITLE
ivi-controller: support to setting desktop surface id earlier

### DIFF
--- a/ivi-id-agent-modules/ivi-id-agent/CMakeLists.txt
+++ b/ivi-id-agent-modules/ivi-id-agent/CMakeLists.txt
@@ -28,6 +28,7 @@ pkg_check_modules(PIXMAN pixman-1 REQUIRED)
 pkg_check_modules(LIBWESTON_DESKTOP libweston-desktop-10 REQUIRED)
 pkg_check_modules(LIBWESTON libweston-10 REQUIRED)
 
+GET_TARGET_PROPERTY(IVI_CONTROLLER_INCLUDE_DIRS ivi-controller INCLUDE_DIRECTORIES)
 find_package(Threads REQUIRED)
 
 include_directories(
@@ -35,6 +36,7 @@ include_directories(
     ${WAYLAND_SERVER_INCLUDE_DIRS}
     ${WESTON_INCLUDE_DIRS}
     ${PIXMAN_INCLUDE_DIRS}
+    ${IVI_CONTROLLER_INCLUDE_DIRS}
 )
 
 link_directories(

--- a/ivi-id-agent-modules/ivi-id-agent/src/ivi-id-agent.c
+++ b/ivi-id-agent-modules/ivi-id-agent/src/ivi-id-agent.c
@@ -29,6 +29,7 @@
 #include <libweston-desktop/libweston-desktop.h>
 #include <libweston/config-parser.h>
 #include <ivi-layout-export.h>
+#include "ivi-controller.h"
 
 #ifndef INVALID_ID
 #define INVALID_ID 0xFFFFFFFF
@@ -52,7 +53,7 @@ struct ivi_id_agent
     struct weston_compositor *compositor;
     const struct ivi_layout_interface *interface;
 
-    struct wl_listener desktop_surface_configured;
+    struct wl_listener id_allocation_listener;
     struct wl_listener destroy_listener;
     struct wl_listener surface_removed;
 };
@@ -170,11 +171,11 @@ ivi_failed:
 }
 
 static void
-desktop_surface_event_configure(struct wl_listener *listener,
+id_allocation_event_request(struct wl_listener *listener,
         void *data)
 {
     struct ivi_id_agent *ida = wl_container_of(listener, ida,
-            desktop_surface_configured);
+            id_allocation_listener);
 
     struct ivi_layout_surface *layout_surface =
             (struct ivi_layout_surface *) data;
@@ -327,10 +328,14 @@ ivi_failed:
 }
 
 WL_EXPORT int32_t
-id_agent_module_init(struct weston_compositor *compositor,
-        const struct ivi_layout_interface *interface)
+id_agent_module_init(struct ivishell *shell)
 {
     struct ivi_id_agent *ida = NULL;
+
+    if (shell == NULL || shell->interface == NULL || shell->compositor == NULL) {
+        weston_log("bad ivishell input\n");
+        goto ivi_failed;
+    }
 
     ida = calloc(1, sizeof *ida);
     if (ida == NULL) {
@@ -338,16 +343,15 @@ id_agent_module_init(struct weston_compositor *compositor,
         goto ivi_failed;
     }
 
-    ida->compositor = compositor;
-    ida->interface = interface;
-    ida->desktop_surface_configured.notify = desktop_surface_event_configure;
+    ida->compositor = shell->compositor;
+    ida->interface = shell->interface;
+    ida->id_allocation_listener.notify = id_allocation_event_request;
     ida->destroy_listener.notify = id_agent_module_deinit;
     ida->surface_removed.notify = surface_event_remove;
 
-    wl_signal_add(&compositor->destroy_signal, &ida->destroy_listener);
-    ida->interface->add_listener_configure_desktop_surface(
-            &ida->desktop_surface_configured);
-    interface->add_listener_remove_surface(&ida->surface_removed);
+    wl_signal_add(&ida->compositor->destroy_signal, &ida->destroy_listener);
+    wl_signal_add(&shell->id_allocation_request_signal, &ida->id_allocation_listener);
+    ida->interface->add_listener_remove_surface(&ida->surface_removed);
 
     wl_list_init(&ida->app_list);
     if(read_config(ida) != 0) {
@@ -374,7 +378,7 @@ deinit(struct ivi_id_agent *ida)
         free(db_elem);
     }
 
-    wl_list_remove(&ida->desktop_surface_configured.link);
+    wl_list_remove(&ida->id_allocation_listener.link);
     wl_list_remove(&ida->destroy_listener.link);
     wl_list_remove(&ida->surface_removed.link);
     free(ida);

--- a/weston-ivi-shell/CMakeLists.txt
+++ b/weston-ivi-shell/CMakeLists.txt
@@ -27,6 +27,7 @@ pkg_check_modules(WAYLAND_SERVER wayland-server>=1.13.0 REQUIRED)
 pkg_check_modules(WESTON weston>=5.0.0 REQUIRED)
 pkg_check_modules(PIXMAN pixman-1 REQUIRED)
 pkg_check_modules(LIBWESTON libweston-10 REQUIRED)
+pkg_check_modules(LIBWESTON_DESKTOP libweston-desktop-11 REQUIRED)
 
 find_program(WAYLAND_SCANNER_EXECUTABLE NAMES wayland-scanner)
 
@@ -63,6 +64,7 @@ include_directories(
 link_directories(
     ${WAYLAND_SERVER_LIBRARY_DIRS}
     ${PIXMAN_LIBRARY_DIRS}
+    ${LIBWESTON_DESKTOP_LIBRARY_DIRS}
 )
 
 
@@ -77,6 +79,7 @@ set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "")
 set(LIBS
     ${LIBS}
     ${WAYLAND_SERVER_LIBRARIES}
+    ${LIBWESTON_DESKTOP_LIBRARIES}
 )
 
 set(CMAKE_C_LDFLAGS "-module -avoid-version")

--- a/weston-ivi-shell/src/ivi-controller.h
+++ b/weston-ivi-shell/src/ivi-controller.h
@@ -66,10 +66,12 @@ struct ivishell {
 
     struct wl_signal ivisurface_created_signal;
     struct wl_signal ivisurface_removed_signal;
+    struct wl_signal id_allocation_request_signal;
 
     struct wl_listener surface_created;
     struct wl_listener surface_removed;
     struct wl_listener surface_configured;
+    struct wl_listener desktop_surface_configured;
 
     struct wl_listener layer_created;
     struct wl_listener layer_removed;


### PR DESCRIPTION
On weston 11, with the commit [1], the ivi-layout emits the surface create event for desktop surface is earlier.

This make the sequence issue when id-agent hasn't already setup the surface id for desktop surface, but the ivi-controller is going to send the surface create event to client with INVALID id.

[1] https://gitlab.freedesktop.org/wayland/weston/-/commit/924e79f4f