### PR TITLE
ivi-controller: mapping bkgnd surface and view before repain

### DIFF
--- a/weston-ivi-shell/src/ivi-controller.c
+++ b/weston-ivi-shell/src/ivi-controller.c
@@ -1907,6 +1907,8 @@ surface_event_configure(struct wl_listener *listener, void *data)
             shell->bkgnd_view = weston_view_create(w_surface);
             weston_layer_entry_insert(&shell->bkgnd_layer.view_list,
                                       &shell->bkgnd_view->layer_link);
+            weston_surface_map(w_surface);
+            shell->bkgnd_view->is_mapped = true;
         }
 
         set_bkgnd_surface_prop(shell);


### PR DESCRIPTION
Weston 11 commit [1] don't allow to paint the views if it or its surface didn't map. So, need to call weston_surface_map and set the map of view to true.

[1] https://gitlab.freedesktop.org/wayland/weston/-/commit/f962b4895