### PR TITLE
simple-weston-client.c: avoid to use STDOUT_FILENO and STDIN_FILENO

### DIFF
--- a/ivi-layermanagement-examples/simple-weston-client/src/simple-weston-client.c
+++ b/ivi-layermanagement-examples/simple-weston-client/src/simple-weston-client.c
@@ -718,15 +718,12 @@ weston_dlt_thread_function(void *data)
     DLT_REGISTER_CONTEXT(weston_dlt_context, ctid, WESTON_DLT_CONTEXT_DESC);
 #endif
     wlcontext = (WaylandContextStruct*)data;
-    /*make the stdin as read end of the pipe*/
-    dup2(wlcontext->pipefd[0], STDIN_FILENO);
-
     while (running && wlcontext->thread_running)
     {
         char str[MAXSTRLEN] = {0};
         int i = -1;
 
-        /* read from std-in(read end of pipe) till newline char*/
+        /* read from read end of pipe till newline char*/
         do {
             i++;
             if(read(wlcontext->pipefd[0], &str[i], 1) < 0)
@@ -876,7 +873,17 @@ int main (int argc, const char * argv[])
     /*init debug stream list*/
     wl_list_init(&wlcontext->stream_list);
     get_debug_streams(wlcontext);
-    wlcontext->debug_fd = STDOUT_FILENO;
+    /* create the pipe to forward the data
+    * pipe[1] - write end
+    * pipe[0] - read end
+    * weston will write to pipe[1] and the
+    * dlt_ctx_thread will read from pipe[0] */
+    if((pipe(wlcontext->pipefd)) < 0) {
+        printf("Error in pipe() processing : %s", strerror(errno));
+        goto ErrorPipe;
+    }
+
+    wlcontext->debug_fd = wlcontext->pipefd[1];
 #else
     fprintf(stderr, "WARNING: weston_debug protocol is not available\n");
 #endif
@@ -896,16 +903,6 @@ int main (int argc, const char * argv[])
 #ifdef LIBWESTON_DEBUG_PROTOCOL
     if (!wl_list_empty(&wlcontext->stream_list) &&
             wlcontext->debug_iface) {
-        /* create the pipe b/w stdout and stdin
-         * stdout - write end
-         * stdin - read end
-         * weston will write to stdout and the
-         * dlt_ctx_thread will read from stdin */
-        if((pipe(wlcontext->pipefd)) < 0)
-            printf("Error in pipe() processing : %s", strerror(errno));
-
-        dup2(wlcontext->pipefd[1], STDOUT_FILENO);
-
         wlcontext->thread_running = 1;
         pthread_create(&wlcontext->dlt_ctx_thread, NULL,
                 weston_dlt_thread_function, wlcontext);
@@ -929,18 +926,19 @@ Error:
 
     if(wlcontext->thread_running)
     {
-        close(wlcontext->pipefd[1]);
-        close(STDOUT_FILENO);
         wlcontext->thread_running = 0;
         pthread_join(wlcontext->dlt_ctx_thread, NULL);
-        close(wlcontext->pipefd[0]);
     }
 #endif
 
     destroy_bkgnd_surface(wlcontext);
 ErrorContext:
     destroy_wayland_context(wlcontext);
-
+#ifdef LIBWESTON_DEBUG_PROTOCOL
+    close(wlcontext->pipefd[0]);
+    close(wlcontext->pipefd[1]);
+ErrorPipe:
+#endif
     free(bkgnd_settings);
     close(wlcontext->signal_fd);
 ErrorSignalFd:


### PR DESCRIPTION
The signalfd() maybe 0 when this app is loaded by Weston (setup ivi-client-name in weston.ini). The fd same with STDIN_FILENO, if anything write to STDIN, the signal handler will be occured unexpectedly.

Using the define fd from pipe() to avoid the issue.