### PR TITLE
CMakeList.txt: Supporting the libweston flexiable version

### DIFF
--- a/ivi-id-agent-modules/ivi-id-agent/CMakeLists.txt
+++ b/ivi-id-agent-modules/ivi-id-agent/CMakeLists.txt
@@ -23,9 +23,13 @@ project(ivi-id-agent)
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(WAYLAND_SERVER wayland-server REQUIRED)
-pkg_check_modules(WESTON weston>=6.0.0 REQUIRED)
 pkg_check_modules(PIXMAN pixman-1 REQUIRED)
-pkg_check_modules(LIBWESTON_DESKTOP libweston-desktop-9 REQUIRED)
+pkg_check_modules(WESTON weston>=6.0.0 REQUIRED)
+
+if(NOT DEFINED WESTON_MAJOR_VERSION)
+    string(REGEX MATCH ^[0-9]* WESTON_MAJOR_VERSION ${WESTON_VERSION})
+endif()
+pkg_check_modules(LIBWESTON_DESKTOP libweston-desktop-${WESTON_MAJOR_VERSION} REQUIRED)
 
 find_package(Threads REQUIRED)
 

--- a/ivi-layermanagement-examples/simple-weston-client/CMakeLists.txt
+++ b/ivi-layermanagement-examples/simple-weston-client/CMakeLists.txt
@@ -22,14 +22,24 @@ project (simple-weston-client)
 find_package(PkgConfig)
 pkg_check_modules(WAYLAND_CLIENT wayland-client REQUIRED)
 pkg_check_modules(WAYLAND_CURSOR wayland-cursor REQUIRED)
-pkg_check_modules(LIBWESTON_PROTOCOLS libweston-9-protocols QUIET)
+
+if(NOT DEFINED WESTON_MAJOR_VERSION)
+    pkg_check_modules(WESTON weston>=6.0.0 QUIET)
+    if (${WESTON_FOUND})
+        string(REGEX MATCH ^[0-9]* WESTON_MAJOR_VERSION ${WESTON_VERSION})
+    else()
+        message(FATAL_ERROR "Need to pass the Weston major version via -DWESTON_MAJOR_VERSION")
+    endif()
+endif()
+
+pkg_check_modules(LIBWESTON_PROTOCOLS libweston-${WESTON_MAJOR_VERSION}-protocols QUIET)
 
 if(${LIBWESTON_PROTOCOLS_FOUND})
     #check for DLT
     pkg_check_modules(DLT automotive-dlt QUIET)
 
     #import the pkgdatadir from libweston-protocols pkgconfig file
-    execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE} --variable=pkgdatadir libweston-9-protocols
+    execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE} --variable=pkgdatadir libweston-${WESTON_MAJOR_VERSION}-protocols
                     OUTPUT_VARIABLE WestonProtocols_PKGDATADIR)
     string(REGEX REPLACE "[\r\n]" "" WestonProtocols_PKGDATADIR "${WestonProtocols_PKGDATADIR}")
     SET(LIBWESTON_PROTOCOLS_PKGDATADIR ${WestonProtocols_PKGDATADIR})


### PR DESCRIPTION
Avoid to modify the CMake files when upgrade the new Weston version, trying to get the special version of libweston packages via Weston version. Also, user can pass the special version via the -DWESTON_MAJOR_VERSION variable.