### PR TITLE
CMakeLists.txt: fix build failed with newer version of meson

### DIFF
--- a/ivi-id-agent-modules/ivi-id-agent/CMakeLists.txt
+++ b/ivi-id-agent-modules/ivi-id-agent/CMakeLists.txt
@@ -26,6 +26,7 @@ pkg_check_modules(WAYLAND_SERVER wayland-server REQUIRED)
 pkg_check_modules(WESTON weston>=6.0.0 REQUIRED)
 pkg_check_modules(PIXMAN pixman-1 REQUIRED)
 pkg_check_modules(LIBWESTON_DESKTOP libweston-desktop-10 REQUIRED)
+pkg_check_modules(LIBWESTON libweston-10 REQUIRED)
 
 find_package(Threads REQUIRED)
 
@@ -66,5 +67,5 @@ target_link_libraries(${PROJECT_NAME} ${LIBS})
 
 install (
     TARGETS             ${PROJECT_NAME}
-    LIBRARY DESTINATION ${WESTON_LIBDIR}/weston
+    LIBRARY DESTINATION ${LIBWESTON_LIBDIR}/weston
 )

--- a/ivi-input-modules/ivi-input-controller/CMakeLists.txt
+++ b/ivi-input-modules/ivi-input-controller/CMakeLists.txt
@@ -25,6 +25,7 @@ find_package(PkgConfig REQUIRED)
 pkg_check_modules(WAYLAND_SERVER wayland-server REQUIRED)
 pkg_check_modules(WESTON weston>=5.0.0 REQUIRED)
 pkg_check_modules(PIXMAN pixman-1 REQUIRED)
+pkg_check_modules(LIBWESTON libweston-10 REQUIRED)
 
 GET_TARGET_PROPERTY(ILM_COMMON_INCLUDE_DIRS ilmCommon INCLUDE_DIRECTORIES)
 GET_TARGET_PROPERTY(IVI_CONTROLLER_INCLUDE_DIRS ivi-controller INCLUDE_DIRECTORIES)
@@ -91,5 +92,5 @@ target_link_libraries(${PROJECT_NAME} ${LIBS})
 
 install (
     TARGETS             ${PROJECT_NAME}
-    LIBRARY DESTINATION ${WESTON_LIBDIR}/weston
+    LIBRARY DESTINATION ${LIBWESTON_LIBDIR}/weston
 )

--- a/weston-ivi-shell/CMakeLists.txt
+++ b/weston-ivi-shell/CMakeLists.txt
@@ -26,6 +26,7 @@ find_package(PkgConfig REQUIRED)
 pkg_check_modules(WAYLAND_SERVER wayland-server>=1.13.0 REQUIRED)
 pkg_check_modules(WESTON weston>=5.0.0 REQUIRED)
 pkg_check_modules(PIXMAN pixman-1 REQUIRED)
+pkg_check_modules(LIBWESTON libweston-10 REQUIRED)
 
 find_program(WAYLAND_SCANNER_EXECUTABLE NAMES wayland-scanner)
 
@@ -89,5 +90,5 @@ target_link_libraries(${PROJECT_NAME} ${LIBS})
 
 install (
     TARGETS             ${PROJECT_NAME}
-    LIBRARY DESTINATION ${WESTON_LIBDIR}/weston
+    LIBRARY DESTINATION ${LIBWESTON_LIBDIR}/weston
 )


### PR DESCRIPTION
If weston built with meson version 0.62 or higher, the weston.pc file will not generate the libdir variable. wayland-ivi-extension base on this to find the weston modules plugin directory.

Switch to base on libdir variable of libweston.pc for get our purpose.