### PR TITLE
Fix build warning

### DIFF
--- a/ivi-layermanagement-api/ilmClient/src/ilm_client_wayland_platform.c
+++ b/ivi-layermanagement-api/ilmClient/src/ilm_client_wayland_platform.c
@@ -126,8 +126,8 @@ registry_handle_client_remove(void *data, struct wl_registry *registry,
 }
 
 static const struct wl_registry_listener registry_client_listener = {
-    registry_handle_client,
-    registry_handle_client_remove
+    .global = registry_handle_client,
+    .global_remove = registry_handle_client_remove
 };
 
 static struct ilm_client_context ilm_context = {0};

--- a/ivi-layermanagement-api/ilmControl/src/ilm_control_wayland_platform.c
+++ b/ivi-layermanagement-api/ilmControl/src/ilm_control_wayland_platform.c
@@ -194,10 +194,10 @@ output_listener_scale(void *data,
 }
 
 static struct wl_output_listener output_listener = {
-    output_listener_geometry,
-    output_listener_mode,
-    output_listener_done,
-    output_listener_scale
+    .geometry = output_listener_geometry,
+    .mode = output_listener_mode,
+    .done = output_listener_done,
+    .scale = output_listener_scale
 };
 
 static void
@@ -987,8 +987,8 @@ registry_handle_control_remove(void *data, struct wl_registry *registry, uint32_
 
 static const struct wl_registry_listener
 registry_control_listener= {
-    registry_handle_control,
-    registry_handle_control_remove
+    .global = registry_handle_control,
+    .global_remove = registry_handle_control_remove
 };
 
 struct ilm_control_context ilm_context;

--- a/ivi-layermanagement-api/test/ilm_check_env.cpp
+++ b/ivi-layermanagement-api/test/ilm_check_env.cpp
@@ -44,11 +44,6 @@ class TestEnvChecking
         const char *acpInterface,
         uint32_t aVersion);
 
-    static constexpr struct wl_registry_listener mRegistryListener = {
-      RegistryHandleGlobal,
-      nullptr
-    };
-
     static TestEnvChecking *mpInstance;
     TestEnvChecking();
 };
@@ -75,6 +70,11 @@ TestEnvChecking::TestEnvChecking(): mpDisplay(nullptr), mpRegistry(nullptr),
     mCheck = false;
     return;
   }
+
+  static struct wl_registry_listener mRegistryListener;
+
+  memset(&mRegistryListener, 0, sizeof mRegistryListener);
+  mRegistryListener.global = RegistryHandleGlobal;
 
   ret = wl_registry_add_listener(mpRegistry, &mRegistryListener, this);
   if (ret < 0) {

--- a/ivi-layermanagement-examples/EGLWLInputEventExample/include/WLEyesRenderer.h
+++ b/ivi-layermanagement-examples/EGLWLInputEventExample/include/WLEyesRenderer.h
@@ -34,8 +34,32 @@ bool DrawEyes(WLEGLSurface* surface, WLEyes* eyes);
 void DrawFillPoly(const int nPoint, const float* points, const float color[4]);
 void DrawPoly(const int nPoint, const float* points, const float color[4], int width);
 
-extern const struct wl_pointer_listener PointerListener;
-extern const struct wl_keyboard_listener KeyboardListener;
-extern const struct wl_touch_listener TouchListener;
+struct PointerListener_t {
+public:
+    PointerListener_t ();
+    const struct wl_pointer_listener * GetCoreListener() const;
+private:
+    struct wl_pointer_listener mPointerListener;
+};
+
+struct KeyboardListener_t {
+public:
+    KeyboardListener_t ();
+    const struct wl_keyboard_listener * GetCoreListener() const;
+private:
+    struct wl_keyboard_listener mKeyboardListener;
+};
+
+struct TouchListener_t {
+public:
+    TouchListener_t ();
+    const struct wl_touch_listener * GetCoreListener() const;
+private:
+    struct wl_touch_listener mTouchListener;
+};
+
+extern const struct PointerListener_t PointerListener;
+extern const struct KeyboardListener_t KeyboardListener;
+extern const struct TouchListener_t TouchListener;
 
 #endif /* _WLEYESRENDERER_H_ */

--- a/ivi-layermanagement-examples/EGLWLInputEventExample/src/WLContext.cpp
+++ b/ivi-layermanagement-examples/EGLWLInputEventExample/src/WLContext.cpp
@@ -27,15 +27,40 @@
 
 //////////////////////////////////////////////////////////////////////////////
 
-static struct wl_registry_listener registryListener = {
-    WLContext::RegistryHandleGlobal,
-    NULL
+struct registryListener_t {
+public:
+    registryListener_t ()
+    {
+        memset(&mRegistryListener, 0, sizeof mRegistryListener);
+        mRegistryListener.global = WLContext::RegistryHandleGlobal;
+    }
+    const struct wl_registry_listener * GetCoreListener() const
+    {
+        const struct wl_registry_listener * ret = &mRegistryListener;
+        return ret;
+    }
+private:
+    struct wl_registry_listener mRegistryListener;
 };
 
-static struct wl_seat_listener seatListener = {
-    WLContext::SeatHandleCapabilities,
-    NULL
+struct seatListener_t {
+public:
+    seatListener_t ()
+    {
+        memset(&mSeatListener, 0, sizeof mSeatListener);
+        mSeatListener.capabilities = WLContext::SeatHandleCapabilities;
+    }
+    const struct wl_seat_listener * GetCoreListener() const
+    {
+        const struct wl_seat_listener * ret = &mSeatListener;
+        return ret;
+    }
+private:
+    struct wl_seat_listener mSeatListener;
 };
+
+static const struct registryListener_t registryListener;
+static const struct seatListener_t seatListener;
 
 //////////////////////////////////////////////////////////////////////////////
 
@@ -139,7 +164,7 @@ WLContext::RegistryHandleGlobal(void* data,
             seat_data->ctx = surface;
             seat_data->wlSeat = (wl_seat*)wl_registry_bind(
                                  registry, name, &wl_seat_interface, 1);
-            wl_seat_add_listener(seat_data->wlSeat, &seatListener,
+            wl_seat_add_listener(seat_data->wlSeat, seatListener.GetCoreListener(),
                                  (void *)seat_data);
         }
     } while (0);
@@ -213,7 +238,7 @@ WLContext::InitWLContext(const struct wl_pointer_listener* wlPointerListener,
     m_wlDisplay = wl_display_connect(NULL);
 
     m_wlRegistry = wl_display_get_registry(m_wlDisplay);
-    wl_registry_add_listener(m_wlRegistry, &registryListener, this);
+    wl_registry_add_listener(m_wlRegistry, registryListener.GetCoreListener(), this);
     wl_display_dispatch(m_wlDisplay);
     wl_display_roundtrip(m_wlDisplay);
 

--- a/ivi-layermanagement-examples/EGLWLInputEventExample/src/main.cpp
+++ b/ivi-layermanagement-examples/EGLWLInputEventExample/src/main.cpp
@@ -78,7 +78,9 @@ int main(int argc, char **argv)
     signal(SIGINT,SigFunc);
 
     wlContext = new WLContext();
-    wlContext->InitWLContext(&PointerListener, &KeyboardListener, &TouchListener);
+    wlContext->InitWLContext(PointerListener.GetCoreListener(),
+                             KeyboardListener.GetCoreListener(),
+                             TouchListener.GetCoreListener());
 
     int const fd = wl_display_get_fd(wlContext->GetWLDisplay());
 

--- a/ivi-layermanagement-examples/EGLWLMockNavigation/src/House.cpp
+++ b/ivi-layermanagement-examples/EGLWLMockNavigation/src/House.cpp
@@ -145,7 +145,7 @@ void House::render()
                 m_texCoords[6].x = numElements;
                 m_texCoords[6].y = numElements;
             } else {
-                memset(m_texCoords, 0, sizeof(m_texCoords));
+                memset((void*)m_texCoords, 0, sizeof(m_texCoords));
             }
             glEnableVertexAttribArray(0);
             glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 0, m_vertex);

--- a/ivi-layermanagement-examples/multi-touch-viewer/src/multi-touch-viewer.c
+++ b/ivi-layermanagement-examples/multi-touch-viewer/src/multi-touch-viewer.c
@@ -139,7 +139,7 @@ frame_callback(void *p_data, struct wl_callback *p_cb, uint32_t time)
 }
 
 static const struct wl_callback_listener frame_listener = {
-    frame_callback
+    .done = frame_callback
 };
 
 static void
@@ -225,13 +225,13 @@ touch_handle_orientation(void *p_data, struct wl_touch *p_touch,
 }
 
 static const struct wl_touch_listener touch_listener = {
-    touch_handle_down,
-    touch_handle_up,
-    touch_handle_motion,
-    touch_handle_frame,
-    touch_handle_cancel,
-    touch_handle_shape,
-    touch_handle_orientation
+    .down = touch_handle_down,
+    .up = touch_handle_up,
+    .motion = touch_handle_motion,
+    .frame = touch_handle_frame,
+    .cancel = touch_handle_cancel,
+    .shape = touch_handle_shape,
+    .orientation = touch_handle_orientation
 };
 
 static void
@@ -253,8 +253,7 @@ seat_capabilities(void *p_data, struct wl_seat *p_seat, uint32_t caps)
 }
 
 static const struct wl_seat_listener seat_listener = {
-    seat_capabilities,
-    NULL /* name: since version 2 */
+    .capabilities = seat_capabilities
 };
 
 static void

--- a/ivi-layermanagement-examples/multi-touch-viewer/src/multi-touch-viewer.c
+++ b/ivi-layermanagement-examples/multi-touch-viewer/src/multi-touch-viewer.c
@@ -657,7 +657,7 @@ usage(int status)
 static void 
 parse_options(int argc, char *argv[])
 {
-    int opt = -1, option_index = 0;
+    int opt = -1;
     static const struct option options[] = {
         { "help", no_argument, NULL, 'h' },
         { "print-log", no_argument, NULL, 'p' },

--- a/ivi-layermanagement-examples/multi-touch-viewer/src/window.c
+++ b/ivi-layermanagement-examples/multi-touch-viewer/src/window.c
@@ -109,8 +109,8 @@ registry_handle_remove(void *p_data, struct wl_registry *p_registry,
 }
 
 static const struct wl_registry_listener registry_listener = {
-    registry_handle_global,
-    registry_handle_remove
+    .global = registry_handle_global,
+    .global_remove = registry_handle_remove
 };
 
 /**
@@ -135,8 +135,8 @@ surface_leave(void *p_data, struct wl_surface *p_surface,
 }
 
 static const struct wl_surface_listener surface_listener = {
-    surface_enter,
-    surface_leave
+    .enter = surface_enter,
+    .leave = surface_leave
 };
 
 /**
@@ -171,9 +171,9 @@ shell_surface_handle_popup_done(void *p_data,
 }
 
 static const struct wl_shell_surface_listener shell_surface_listener = {
-    shell_surface_handle_ping,
-    shell_surface_handle_configure,
-    shell_surface_handle_popup_done
+    .ping = shell_surface_handle_ping,
+    .configure = shell_surface_handle_configure,
+    .popup_done = shell_surface_handle_popup_done
 };
 
 /**
@@ -199,7 +199,7 @@ frame_callback(void *p_data, struct wl_callback *p_cb, uint32_t time)
 }
 
 static const struct wl_callback_listener frame_listener = {
-    frame_callback
+    .done = frame_callback
 };
 
 static void

--- a/ivi-layermanagement-examples/simple-weston-client/src/simple-weston-client.c
+++ b/ivi-layermanagement-examples/simple-weston-client/src/simple-weston-client.c
@@ -267,7 +267,7 @@ shm_format(void *data, struct wl_shm *wl_shm, uint32_t format)
 }
 
 static struct wl_shm_listener shm_listenter = {
-    shm_format
+    .format = shm_format
 };
 
 static int create_cursors(WaylandContextStruct* wlcontext) {
@@ -392,15 +392,15 @@ PointerHandleAxisDiscrete(void *data, struct wl_pointer *wl_pointer,
 }
 
 static struct wl_pointer_listener pointer_listener = {
-    PointerHandleEnter,
-    PointerHandleLeave,
-    PointerHandleMotion,
-    PointerHandleButton,
-    PointerHandleAxis,
-    PointerHandleFrame,
-    PointerHandleAxisSource,
-    PointerHandleAxisStop,
-    PointerHandleAxisDiscrete
+    .enter = PointerHandleEnter,
+    .leave = PointerHandleLeave,
+    .motion = PointerHandleMotion,
+    .button = PointerHandleButton,
+    .axis = PointerHandleAxis,
+    .frame = PointerHandleFrame,
+    .axis_source = PointerHandleAxisSource,
+    .axis_stop = PointerHandleAxisStop,
+    .axis_discrete = PointerHandleAxisDiscrete
 };
 
 static void
@@ -439,8 +439,8 @@ seat_name(void *data, struct wl_seat *wl_seat, const char *name)
 }
 
 static struct wl_seat_listener seat_Listener = {
-    seat_handle_capabilities,
-    seat_name
+    .capabilities = seat_handle_capabilities,
+    .name = seat_name
 };
 
 #ifdef LIBWESTON_DEBUG_PROTOCOL
@@ -520,8 +520,8 @@ registry_handle_global_remove(void *data, struct wl_registry *registry,
 }
 
 static const struct wl_registry_listener registry_listener = {
-    registry_handle_global,
-    registry_handle_global_remove
+    .global = registry_handle_global,
+    .global_remove = registry_handle_global_remove
 };
 
 int init_wayland_context(WaylandContextStruct* wlcontext)


### PR DESCRIPTION
[  1%] Generating ivi-application-protocol.c
Using "code" is deprecated - use private-code or public-code.
See the help page for details.
[  2%] Generating ivi-application-client-protocol.h
[  3%] Building C object protocol/CMakeFiles/ivi-application.dir/ivi-application-protocol.c.o
[  4%] Linking C shared library libivi-application.so
[  4%] Built target ivi-application
[  5%] Generating ivi-wm-server-protocol.h
[  6%] Generating ivi-wm-protocol.c
Using "code" is deprecated - use private-code or public-code.
See the help page for details.
[  7%] Building C object weston-ivi-shell/CMakeFiles/ivi-controller.dir/src/ivi-controller.c.o
[  8%] Building C object weston-ivi-shell/CMakeFiles/ivi-controller.dir/ivi-wm-protocol.c.o
[  9%] Linking C shared module ivi-controller.so
[  9%] Built target ivi-controller
[ 10%] Generating ivi-wm-protocol.c
Using "code" is deprecated - use private-code or public-code.
See the help page for details.
[ 11%] Generating ivi-input-client-protocol.h
[ 12%] Generating ivi-input-protocol.c
Using "code" is deprecated - use private-code or public-code.
See the help page for details.
[ 13%] Generating ivi-wm-client-protocol.h
[ 14%] Building C object ivi-layermanagement-api/ilmControl/CMakeFiles/ilmControl.dir/src/ilm_control_wayland_platform.c.o
[ 15%] Building C object ivi-layermanagement-api/ilmControl/CMakeFiles/ilmControl.dir/src/bitmap.c.o
[ 16%] Building C object ivi-layermanagement-api/ilmControl/CMakeFiles/ilmControl.dir/src/writepng.c.o
[ 17%] Building C object ivi-layermanagement-api/ilmControl/CMakeFiles/ilmControl.dir/ivi-wm-protocol.c.o
[ 18%] Building C object ivi-layermanagement-api/ilmControl/CMakeFiles/ilmControl.dir/ivi-input-protocol.c.o
[ 19%] Linking C shared library libilmControl.so
[ 19%] Built target ilmControl
[ 20%] Building C object ivi-layermanagement-api/ilmCommon/CMakeFiles/ilmCommon.dir/src/ilm_common.c.o
[ 20%] Building C object ivi-layermanagement-api/ilmCommon/CMakeFiles/ilmCommon.dir/src/ilm_common_wayland_platform.c.o
[ 21%] Linking C shared library libilmCommon.so
[ 21%] Built target ilmCommon
[ 22%] Generating ivi-application-protocol.c
Using "code" is deprecated - use private-code or public-code.
See the help page for details.
[ 23%] Generating ivi-application-client-protocol.h
[ 24%] Building C object ivi-layermanagement-api/ilmClient/CMakeFiles/ilmClient.dir/src/ilm_client.c.o
[ 25%] Building C object ivi-layermanagement-api/ilmClient/CMakeFiles/ilmClient.dir/src/ilm_client_wayland_platform.c.o
[ 26%] Building C object ivi-layermanagement-api/ilmClient/CMakeFiles/ilmClient.dir/ivi-application-protocol.c.o
[ 27%] Linking C shared library libilmClient.so
[ 27%] Built target ilmClient
[ 28%] Generating ivi-input-protocol.c
Using "code" is deprecated - use private-code or public-code.
See the help page for details.
[ 29%] Generating ivi-input-client-protocol.h
[ 30%] Building C object ivi-layermanagement-api/ilmInput/CMakeFiles/ilmInput.dir/src/ilm_input.c.o
[ 31%] Building C object ivi-layermanagement-api/ilmInput/CMakeFiles/ilmInput.dir/ivi-input-protocol.c.o
[ 32%] Linking C shared library libilmInput.so
[ 32%] Built target ilmInput
[ 34%] Building CXX object ivi-layermanagement-examples/LayerManagerControl/CMakeFiles/LayerManagerControl.dir/src/main.cpp.o
[ 35%] Building CXX object ivi-layermanagement-examples/LayerManagerControl/CMakeFiles/LayerManagerControl.dir/src/commands.cpp.o
[ 36%] Building CXX object ivi-layermanagement-examples/LayerManagerControl/CMakeFiles/LayerManagerControl.dir/src/input_commands.cpp.o
[ 37%] Building CXX object ivi-layermanagement-examples/LayerManagerControl/CMakeFiles/LayerManagerControl.dir/src/analyze.cpp.o
[ 38%] Building CXX object ivi-layermanagement-examples/LayerManagerControl/CMakeFiles/LayerManagerControl.dir/src/common.cpp.o
[ 39%] Building CXX object ivi-layermanagement-examples/LayerManagerControl/CMakeFiles/LayerManagerControl.dir/src/control.cpp.o
[ 40%] Building CXX object ivi-layermanagement-examples/LayerManagerControl/CMakeFiles/LayerManagerControl.dir/src/Expression.cpp.o
[ 41%] Building CXX object ivi-layermanagement-examples/LayerManagerControl/CMakeFiles/LayerManagerControl.dir/src/ExpressionInterpreter.cpp.o
[ 42%] Building CXX object ivi-layermanagement-examples/LayerManagerControl/CMakeFiles/LayerManagerControl.dir/src/print.cpp.o
[ 43%] Building CXX object ivi-layermanagement-examples/LayerManagerControl/CMakeFiles/LayerManagerControl.dir/src/sceneio.cpp.o
[ 44%] Building CXX object ivi-layermanagement-examples/LayerManagerControl/CMakeFiles/LayerManagerControl.dir/src/util.cpp.o
[ 45%] Linking CXX executable LayerManagerControl
[ 45%] Built target LayerManagerControl
[ 46%] Generating ivi-application-protocol.c
Using "code" is deprecated - use private-code or public-code.
See the help page for details.
[ 47%] Generating ivi-application-client-protocol.h
[ 48%] Building CXX object ivi-layermanagement-examples/EGLWLMockNavigation/CMakeFiles/EGLWLMockNavigation.dir/src/Camera.cpp.o
[ 49%] Building CXX object ivi-layermanagement-examples/EGLWLMockNavigation/CMakeFiles/EGLWLMockNavigation.dir/src/Car.cpp.o
[ 50%] Building CXX object ivi-layermanagement-examples/EGLWLMockNavigation/CMakeFiles/EGLWLMockNavigation.dir/src/Argument.cpp.o
[ 51%] Building CXX object ivi-layermanagement-examples/EGLWLMockNavigation/CMakeFiles/EGLWLMockNavigation.dir/src/OpenGLES2App.cpp.o
[ 52%] Building CXX object ivi-layermanagement-examples/EGLWLMockNavigation/CMakeFiles/EGLWLMockNavigation.dir/src/Ground.cpp.o
[ 53%] Building CXX object ivi-layermanagement-examples/EGLWLMockNavigation/CMakeFiles/EGLWLMockNavigation.dir/src/House.cpp.o
[ 54%] Building CXX object ivi-layermanagement-examples/EGLWLMockNavigation/CMakeFiles/EGLWLMockNavigation.dir/src/MockNavi.cpp.o
[ 55%] Building CXX object ivi-layermanagement-examples/EGLWLMockNavigation/CMakeFiles/EGLWLMockNavigation.dir/src/Street.cpp.o
[ 56%] Building CXX object ivi-layermanagement-examples/EGLWLMockNavigation/CMakeFiles/EGLWLMockNavigation.dir/src/ShaderBase.cpp.o
[ 57%] Building CXX object ivi-layermanagement-examples/EGLWLMockNavigation/CMakeFiles/EGLWLMockNavigation.dir/src/ShaderLighting.cpp.o
[ 58%] Building CXX object ivi-layermanagement-examples/EGLWLMockNavigation/CMakeFiles/EGLWLMockNavigation.dir/src/main.cpp.o
[ 59%] Building CXX object ivi-layermanagement-examples/EGLWLMockNavigation/CMakeFiles/EGLWLMockNavigation.dir/src/TextureLoader.cpp.o
[ 60%] Building CXX object ivi-layermanagement-examples/EGLWLMockNavigation/CMakeFiles/EGLWLMockNavigation.dir/src/ShaderTexture.cpp.o
[ 61%] Building CXX object ivi-layermanagement-examples/EGLWLMockNavigation/CMakeFiles/EGLWLMockNavigation.dir/src/Sky.cpp.o
[ 62%] Building CXX object ivi-layermanagement-examples/EGLWLMockNavigation/CMakeFiles/EGLWLMockNavigation.dir/src/ShaderGradient.cpp.o
[ 63%] Building C object ivi-layermanagement-examples/EGLWLMockNavigation/CMakeFiles/EGLWLMockNavigation.dir/ivi-application-protocol.c.o
[ 64%] Linking CXX executable EGLWLMockNavigation
[ 64%] Built target EGLWLMockNavigation
[ 64%] Generating ivi-application-protocol.c
Using "code" is deprecated - use private-code or public-code.
See the help page for details.
[ 65%] Generating ivi-application-client-protocol.h
[ 67%] Building CXX object ivi-layermanagement-examples/EGLWLInputEventExample/CMakeFiles/EGLWLInputEventExample.dir/src/main.cpp.o
[ 68%] Building CXX object ivi-layermanagement-examples/EGLWLInputEventExample/CMakeFiles/EGLWLInputEventExample.dir/src/WLContext.cpp.o
[ 69%] Building CXX object ivi-layermanagement-examples/EGLWLInputEventExample/CMakeFiles/EGLWLInputEventExample.dir/src/WLEGLSurface.cpp.o
[ 70%] Building CXX object ivi-layermanagement-examples/EGLWLInputEventExample/CMakeFiles/EGLWLInputEventExample.dir/src/WLEyes.cpp.o
[ 71%] Building CXX object ivi-layermanagement-examples/EGLWLInputEventExample/CMakeFiles/EGLWLInputEventExample.dir/src/WLEyesRenderer.cpp.o
[ 72%] Building CXX object ivi-layermanagement-examples/EGLWLInputEventExample/CMakeFiles/EGLWLInputEventExample.dir/src/WLSurface.cpp.o
[ 73%] Building C object ivi-layermanagement-examples/EGLWLInputEventExample/CMakeFiles/EGLWLInputEventExample.dir/ivi-application-protocol.c.o
[ 74%] Linking CXX executable EGLWLInputEventExample
[ 74%] Built target EGLWLInputEventExample
[ 75%] Building C object ivi-layermanagement-examples/layer-add-surfaces/CMakeFiles/layer-add-surfaces.dir/src/layer-add-surfaces.c.o
[ 76%] Linking C executable layer-add-surfaces
[ 76%] Built target layer-add-surfaces
[ 77%] Generating ivi-application-protocol.c
Using "code" is deprecated - use private-code or public-code.
See the help page for details.
[ 78%] Generating ivi-application-client-protocol.h
[ 79%] Building C object ivi-layermanagement-examples/multi-touch-viewer/CMakeFiles/multi-touch-viewer.dir/src/multi-touch-viewer.c.o
[ 80%] Building C object ivi-layermanagement-examples/multi-touch-viewer/CMakeFiles/multi-touch-viewer.dir/src/util.c.o
[ 81%] Building C object ivi-layermanagement-examples/multi-touch-viewer/CMakeFiles/multi-touch-viewer.dir/src/window.c.o
[ 82%] Building C object ivi-layermanagement-examples/multi-touch-viewer/CMakeFiles/multi-touch-viewer.dir/ivi-application-protocol.c.o
[ 83%] Linking C executable multi-touch-viewer
[ 83%] Built target multi-touch-viewer
[ 84%] Generating weston-debug-server-protocol.h
[ 85%] Generating ivi-application-client-protocol.h
[ 86%] Generating ivi-application-protocol.c
Using "code" is deprecated - use private-code or public-code.
See the help page for details.
[ 87%] Generating weston-debug-client-protocol.h
[ 88%] Generating weston-debug-protocol.c
Using "code" is deprecated - use private-code or public-code.
See the help page for details.
[ 89%] Building C object ivi-layermanagement-examples/simple-weston-client/CMakeFiles/simple-weston-client.dir/src/simple-weston-client.c.o
[ 90%] Building C object ivi-layermanagement-examples/simple-weston-client/CMakeFiles/simple-weston-client.dir/ivi-application-protocol.c.o
[ 91%] Building C object ivi-layermanagement-examples/simple-weston-client/CMakeFiles/simple-weston-client.dir/weston-debug-protocol.c.o
[ 92%] Linking C executable simple-weston-client
[ 92%] Built target simple-weston-client
[ 93%] Generating ivi-input-server-protocol.h
[ 94%] Generating ivi-input-protocol.c
Using "code" is deprecated - use private-code or public-code.
See the help page for details.
[ 95%] Building C object ivi-input-modules/ivi-input-controller/CMakeFiles/ivi-input-controller.dir/src/ivi-input-controller.c.o
[ 96%] Building C object ivi-input-modules/ivi-input-controller/CMakeFiles/ivi-input-controller.dir/ivi-input-protocol.c.o
[ 97%] Linking C shared module ivi-input-controller.so
[ 97%] Built target ivi-input-controller
[ 98%] Building C object ivi-id-agent-modules/ivi-id-agent/CMakeFiles/ivi-id-agent.dir/src/ivi-id-agent.c.o
[100%] Linking C shared module ivi-id-agent.so
[100%] Built target ivi-id-agent
Install the project...
-- Install configuration: ""
-- Installing: /home/chien/share/install/lib/libivi-application.so.2.3.0
-- Up-to-date: /home/chien/share/install/lib/libivi-application.so
-- Installing: /home/chien/share/install/include/ilm/ivi-application-client-protocol.h
-- Up-to-date: /home/chien/share/install/share/wayland-protocols/stable/ivi-application/ivi-application.xml
-- Up-to-date: /home/chien/share/install/lib/pkgconfig/ivi-application.pc
-- Installing: /home/chien/share/install/lib/x86_64-linux-gnu/weston/ivi-controller.so
-- Installing: /home/chien/share/install/lib/libilmCommon.so.2.3.0
-- Set runtime path of "/home/chien/share/install/lib/libilmCommon.so.2.3.0" to ""
-- Up-to-date: /home/chien/share/install/lib/libilmCommon.so
-- Up-to-date: /home/chien/share/install/include/ilm/ilm_common.h
-- Up-to-date: /home/chien/share/install/include/ilm/ilm_types.h
-- Up-to-date: /home/chien/share/install/include/ilm/ilm_platform.h
-- Up-to-date: /home/chien/share/install/lib/pkgconfig/ilmCommon.pc
-- Installing: /home/chien/share/install/lib/libilmClient.so.2.3.0
-- Up-to-date: /home/chien/share/install/lib/libilmClient.so
-- Up-to-date: /home/chien/share/install/include/ilm/ilm_client.h
-- Installing: /home/chien/share/install/lib/libilmControl.so.2.3.0
-- Up-to-date: /home/chien/share/install/lib/libilmControl.so
-- Up-to-date: /home/chien/share/install/include/ilm/ilm_control.h
-- Up-to-date: /home/chien/share/install/lib/pkgconfig/ilmControl.pc
-- Installing: /home/chien/share/install/bin/LayerManagerControl
-- Set runtime path of "/home/chien/share/install/bin/LayerManagerControl" to ""
-- Installing: /home/chien/share/install/bin/EGLWLMockNavigation
-- Up-to-date: /home/chien/share/install/share/wayland-ivi-extension/textures
-- Up-to-date: /home/chien/share/install/share/wayland-ivi-extension/textures/car.bmp
-- Up-to-date: /home/chien/share/install/share/wayland-ivi-extension/textures/base.bmp
-- Up-to-date: /home/chien/share/install/share/wayland-ivi-extension/textures/street.bmp
-- Up-to-date: /home/chien/share/install/share/wayland-ivi-extension/textures/sources.txt
-- Up-to-date: /home/chien/share/install/share/wayland-ivi-extension/textures/skyscrapers
-- Up-to-date: /home/chien/share/install/share/wayland-ivi-extension/textures/skyscrapers/facade01.bmp
-- Up-to-date: /home/chien/share/install/share/wayland-ivi-extension/textures/skyscrapers/facade00.bmp
-- Up-to-date: /home/chien/share/install/share/wayland-ivi-extension/textures/skyscrapers/facade03.bmp
-- Up-to-date: /home/chien/share/install/share/wayland-ivi-extension/textures/skyscrapers/facade02.bmp
-- Installing: /home/chien/share/install/bin/EGLWLInputEventExample
-- Installing: /home/chien/share/install/bin/layer-add-surfaces
-- Set runtime path of "/home/chien/share/install/bin/layer-add-surfaces" to ""
-- Installing: /home/chien/share/install/bin/multi-touch-viewer
-- Installing: /home/chien/share/install/bin/simple-weston-client
-- Installing: /home/chien/share/install/lib/libilmInput.so.2.3.0
-- Set runtime path of "/home/chien/share/install/lib/libilmInput.so.2.3.0" to ""
-- Up-to-date: /home/chien/share/install/lib/libilmInput.so
-- Up-to-date: /home/chien/share/install/include/ilm/ilm_input.h
-- Up-to-date: /home/chien/share/install/lib/pkgconfig/ilmInput.pc
-- Installing: /home/chien/share/install/lib/x86_64-linux-gnu/weston/ivi-input-controller.so
-- Installing: /home/chien/share/install/lib/x86_64-linux-gnu/weston/ivi-id-agent.so
-- Set runtime path of "/home/chien/share/install/lib/x86_64-linux-gnu/weston/ivi-id-agent.so" to ""
