### PR TITLE
CMakefiles: remove libweston-desktop dependence

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ include(GNUInstallDirs)
 SET(IVI_EXTENSION_VERSION 2.3.1)
 SET(ILM_API_VERSION 2.3.1)
 
-SET(LIBWESTON_VER 11)
+SET(LIBWESTON_VER 12)
 
 SET( CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -Wall -Wextra -Wno-unused-parameter" )
 SET( CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-unused-parameter" )

--- a/ivi-id-agent-modules/ivi-id-agent/CMakeLists.txt
+++ b/ivi-id-agent-modules/ivi-id-agent/CMakeLists.txt
@@ -26,7 +26,6 @@ pkg_check_modules(WAYLAND_SERVER wayland-server REQUIRED)
 pkg_check_modules(WESTON weston>=6.0.0 REQUIRED)
 pkg_check_modules(PIXMAN pixman-1 REQUIRED)
 pkg_check_modules(LIBWESTON libweston-${LIBWESTON_VER} REQUIRED)
-pkg_check_modules(LIBWESTON_DESKTOP libweston-desktop-${LIBWESTON_VER} REQUIRED)
 
 GET_TARGET_PROPERTY(IVI_CONTROLLER_INCLUDE_DIRS ivi-controller INCLUDE_DIRECTORIES)
 find_package(Threads REQUIRED)
@@ -42,7 +41,6 @@ include_directories(
 link_directories(
     ${WAYLAND_SERVER_LIBRARY_DIRS}
     ${PIXMAN_LIBRARY_DIRS}
-    ${LIBWESTON_DESKTOP_LIBRARY_DIRS}
 )
 
 
@@ -55,7 +53,6 @@ set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "")
 set(LIBS
     ${LIBS}
     ${WAYLAND_SERVER_LIBRARIES}
-    ${LIBWESTON_DESKTOP_LIBRARIES}
 )
 
 set(CMAKE_C_LDFLAGS "-module -avoid-version")

--- a/ivi-id-agent-modules/ivi-id-agent/src/ivi-id-agent.c
+++ b/ivi-id-agent-modules/ivi-id-agent/src/ivi-id-agent.c
@@ -26,7 +26,7 @@
 #include <limits.h>
 
 #include <weston.h>
-#include <libweston-desktop/libweston-desktop.h>
+#include <libweston/desktop.h>
 #include <libweston/config-parser.h>
 #include <ivi-layout-export.h>
 #include "ivi-controller.h"

--- a/weston-ivi-shell/CMakeLists.txt
+++ b/weston-ivi-shell/CMakeLists.txt
@@ -63,7 +63,6 @@ include_directories(
 link_directories(
     ${WAYLAND_SERVER_LIBRARY_DIRS}
     ${PIXMAN_LIBRARY_DIRS}
-    ${LIBWESTON_DESKTOP_LIBRARY_DIRS}
 )
 
 
@@ -78,7 +77,6 @@ set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "")
 set(LIBS
     ${LIBS}
     ${WAYLAND_SERVER_LIBRARIES}
-    ${LIBWESTON_DESKTOP_LIBRARIES}
 )
 
 set(CMAKE_C_LDFLAGS "-module -avoid-version")

--- a/weston-ivi-shell/src/ivi-controller.c
+++ b/weston-ivi-shell/src/ivi-controller.c
@@ -37,7 +37,7 @@
 #include <sys/mman.h>
 
 #include <weston.h>
-#include <libweston-desktop/libweston-desktop.h>
+#include <libweston/desktop.h>
 #include "ivi-wm-server-protocol.h"
 #include "ivi-controller.h"
 


### PR DESCRIPTION
Commit [1] on Weston-12 moved libweston-desktop into libweston, then libweston-desktop.pc was deleted.

[1] https://gitlab.freedesktop.org/wayland/weston/-/commit/1b4def3c4