### PR TITLE
ivi-controller: switch to weston_load_module

### DIFF
--- a/weston-ivi-shell/CMakeLists.txt
+++ b/weston-ivi-shell/CMakeLists.txt
@@ -48,8 +48,6 @@ add_custom_command(
 
 INCLUDE (CheckFunctionExists)
 
-CHECK_FUNCTION_EXISTS(posix_fallocate HAVE_POSIX_FALLOCATE)
-
 configure_file(src/config.h.cmake config.h)
 
 include_directories(

--- a/weston-ivi-shell/src/config.h.cmake
+++ b/weston-ivi-shell/src/config.h.cmake
@@ -1,1 +1,3 @@
-#cmakedefine HAVE_POSIX_FALLOCATE 1
+#pragma once
+
+#define MODULEDIR "@LIBWESTON_LIBDIR@/weston"

--- a/weston-ivi-shell/src/ivi-controller.c
+++ b/weston-ivi-shell/src/ivi-controller.c
@@ -2120,7 +2120,7 @@ load_input_module(struct ivishell *shell)
         return 0;
     }
 
-    input_module_init = wet_load_module_entrypoint(input_module, "input_controller_module_init");
+    input_module_init = weston_load_module(input_module, "input_controller_module_init", MODULEDIR);
     if (!input_module_init)
         return -1;
 
@@ -2194,7 +2194,7 @@ static int load_id_agent_module(struct ivishell *shell)
         return 0;
     }
 
-    id_agent_module_init = wet_load_module_entrypoint(id_agent_module, "id_agent_module_init");
+    id_agent_module_init = weston_load_module(id_agent_module, "id_agent_module_init", MODULEDIR);
     if (!id_agent_module_init)
         return -1;
 


### PR DESCRIPTION
Commit [1] on Weston 12 removed the wet_load_module_entrypoint interface, this requires users switch to weston_load_module for loading other plugins.

[1] https://gitlab.freedesktop.org/wayland/weston/-/commit/eaf2de344