### PR TITLE
ivi-controller: switch to ivi-shell terminal signal

### DIFF
--- a/ivi-id-agent-modules/ivi-id-agent/src/ivi-id-agent.c
+++ b/ivi-id-agent-modules/ivi-id-agent/src/ivi-id-agent.c
@@ -346,10 +346,10 @@ id_agent_module_init(struct ivishell *shell)
     ida->compositor = shell->compositor;
     ida->interface = shell->interface;
     ida->id_allocation_listener.notify = id_allocation_event_request;
-    ida->destroy_listener.notify = id_agent_module_deinit;
     ida->surface_removed.notify = surface_event_remove;
 
-    wl_signal_add(&ida->compositor->destroy_signal, &ida->destroy_listener);
+    ida->interface->shell_add_destroy_listener_once(
+            &ida->destroy_listener, id_agent_module_deinit);
     wl_signal_add(&shell->id_allocation_request_signal, &ida->id_allocation_listener);
     ida->interface->add_listener_remove_surface(&ida->surface_removed);
 

--- a/ivi-input-modules/ivi-input-controller/src/ivi-input-controller.c
+++ b/ivi-input-modules/ivi-input-controller/src/ivi-input-controller.c
@@ -71,7 +71,7 @@ struct input_context {
 
     struct wl_listener surface_created;
     struct wl_listener surface_destroyed;
-    struct wl_listener compositor_destroy_listener;
+    struct wl_listener shell_destroy_listener;
     struct wl_listener seat_create_listener;
 
     char *seat_default_name;
@@ -1263,7 +1263,7 @@ destroy_input_context(struct input_context *ctx)
     wl_list_remove(&ctx->seat_create_listener.link);
     wl_list_remove(&ctx->surface_created.link);
     wl_list_remove(&ctx->surface_destroyed.link);
-    wl_list_remove(&ctx->compositor_destroy_listener.link);
+    wl_list_remove(&ctx->shell_destroy_listener.link);
 
     wl_resource_for_each_safe(resource, tmp_resource, &ctx->resource_list) {
         /*We have set destroy function for this resource.
@@ -1310,7 +1310,7 @@ input_controller_destroy(struct wl_listener *listener, void *data)
     (void)data;
     if (NULL != listener) {
         struct input_context *ctx = wl_container_of(listener,
-                ctx, compositor_destroy_listener);
+                ctx, shell_destroy_listener);
 
         input_controller_deinit(ctx);
     }
@@ -1372,11 +1372,11 @@ create_input_context(struct ivishell *shell)
     /* Add signal handlers for ivi surfaces. */
     ctx->surface_created.notify = handle_surface_create;
     ctx->surface_destroyed.notify = handle_surface_destroy;
-    ctx->compositor_destroy_listener.notify = input_controller_destroy;
 
     wl_signal_add(&ctx->ivishell->ivisurface_created_signal, &ctx->surface_created);
     wl_signal_add(&ctx->ivishell->ivisurface_removed_signal, &ctx->surface_destroyed);
-    wl_signal_add(&ctx->ivishell->compositor->destroy_signal, &ctx->compositor_destroy_listener);
+    ctx->ivishell->interface->shell_add_destroy_listener_once(
+            &ctx->shell_destroy_listener, input_controller_destroy);
 
     ctx->seat_create_listener.notify = &handle_seat_create;
     wl_signal_add(&ctx->ivishell->compositor->seat_created_signal, &ctx->seat_create_listener);

--- a/weston-ivi-shell/src/ivi-controller.c
+++ b/weston-ivi-shell/src/ivi-controller.c
@@ -2252,12 +2252,6 @@ wet_module_init(struct weston_compositor *compositor,
         free(shell);
         return -1;
     }
-    /* add compositor destroy signal after loading input
-     * modules, to ensure input module is the first one to
-     * de-initialize
-     */
-    shell->destroy_listener.notify = ivi_shell_destroy;
-    wl_signal_add(&compositor->destroy_signal, &shell->destroy_listener);
 
     if (shell->bkgnd_surface_id && shell->ivi_client_name) {
         loop = wl_display_get_event_loop(compositor->wl_display);
@@ -2267,6 +2261,13 @@ wet_module_init(struct weston_compositor *compositor,
     if (load_id_agent_module(shell) < 0) {
         weston_log("ivi-controller: id-agent module not loaded\n");
     }
+
+    /* add ivi-shell destroy signal after loading input
+     * modules and id-agent to ensure ivi-controller module is
+     * the last one to de-initialize
+     */
+    shell->interface->shell_add_destroy_listener_once(
+            &shell->destroy_listener, ivi_shell_destroy);
 
     return 0;
 }


### PR DESCRIPTION
Merge request [1] on Weston-12 introduced new signal from ivi-shell. ivi-controller is depended on ivi-shell, so it should depend on ivi-shell instead of compositor when exiting.

[1] https://gitlab.freedesktop.org/wayland/weston/-/merge_requests/1043