### PR TITLE
Rename variables to avoid keywords

### DIFF
--- a/ivi-layermanagement-api/ilmControl/src/ilm_control_wayland_platform.c
+++ b/ivi-layermanagement-api/ilmControl/src/ilm_control_wayland_platform.c
@@ -2156,7 +2156,7 @@ ilm_displaySetRenderOrder(t_ilm_display display,
 static int
 create_screenshot_file(size_t size)
 {
-    const char template[] = "/ivi-shell-screenshot-XXXXXX";
+    const char templatename[] = "/ivi-shell-screenshot-XXXXXX";
     const char *runtimedir;
     char *tmpname;
     int fd;
@@ -2165,11 +2165,11 @@ create_screenshot_file(size_t size)
     if (runtimedir == NULL)
         return -1;
 
-    tmpname = malloc(strlen(runtimedir) + sizeof(template));
+    tmpname = malloc(strlen(runtimedir) + sizeof(templatename));
     if (tmpname == NULL)
         return -1;
 
-    fd = mkstemp(strcat(strcpy(tmpname, runtimedir), template));
+    fd = mkstemp(strcat(strcpy(tmpname, runtimedir), templatename));
 
     if (fd < 0) {
     	free(tmpname);


### PR DESCRIPTION
Some variables has name which same with keyword (not).

Rename these varable to another name