### PR TITLE
ilm_control: fix order during destroying of control resources

### DIFF
--- a/ivi-layermanagement-api/ilmControl/src/ilm_control_wayland_platform.c
+++ b/ivi-layermanagement-api/ilmControl/src/ilm_control_wayland_platform.c
@@ -1099,14 +1099,14 @@ static void destroy_control_resources(void)
         ctx->wl.registry = NULL;
     }
 
-    if (ctx->wl.queue) {
-        wl_event_queue_destroy(ctx->wl.queue);
-        ctx->wl.queue = NULL;
-    }
-
     if (ctx->wl.input_controller) {
         ivi_input_destroy(ctx->wl.input_controller);
         ctx->wl.input_controller = NULL;
+    }
+
+    if (ctx->wl.queue) {
+        wl_event_queue_destroy(ctx->wl.queue);
+        ctx->wl.queue = NULL;
     }
 
     if (0 != pthread_mutex_destroy(&ctx->mutex)) {


### PR DESCRIPTION
fixes following warning from wayland library:

 warning: queue 0x55ccae144a00 destroyed while proxies still attached:
   ivi_input#7 still attached

to avoid the warning we should destroy
the input controller resources (proxies) before destroying the queue of ilm control