### PR TITLE
ilm_input: remove redunant release_instance

### DIFF
--- a/ivi-layermanagement-api/ilmInput/src/ilm_input.c
+++ b/ivi-layermanagement-api/ilmInput/src/ilm_input.c
@@ -262,7 +262,6 @@ ilm_setInputFocus(t_ilm_surface *surfaceIDs, t_ilm_uint num_surfaces,
         && num_surfaces > 1 && is_set == ILM_TRUE) {
         fprintf(stderr,
                 "Cannot set pointer or touch focus for multiple surfaces\n");
-        release_instance();
         return ILM_FAILED;
     }
 


### PR DESCRIPTION
release_instance is called when no sync_and_acquire_instance is called before.