### PR TITLE
ivi-controller: avoid invalid mem access during display hotplug

### DIFF
--- a/weston-ivi-shell/src/ivi-controller.c
+++ b/weston-ivi-shell/src/ivi-controller.c
@@ -874,6 +874,7 @@ set_bkgnd_surface_prop(struct ivishell *shell)
     compositor = shell->compositor;
 
     wl_list_remove(&shell->bkgnd_transform.link);
+    wl_list_init(&shell->bkgnd_transform.link);
     weston_matrix_init(&shell->bkgnd_transform.matrix);
 
     /*find the available screen's resolution*/


### PR DESCRIPTION
On set_bkgnd_surface_prop() API, 'bkgnd_transform.link' is removed from transformation list but it is not initialized, so it may lead to invalid mem access when set_bkgnd_surface_prop() is called again. So initialize the 'bkgnd_transform.link' after the removing it.